### PR TITLE
Get all monthly expenses feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,42 @@ A fun little acronym project I'm starting to help me take back control of my lif
 Should you stumble upon this repository, please excuse any spelling, grammatical errors and just have a little fun. **Strap in**
 
 ## Product View
+
 There will be 3 main pillars Budget, To-do (calendar), Home
 
 ### Budget
-Straightforward, the goal for this module to calculate everything related to a budget that I will create with my wife. We come up with the budget ourselves, set the parameters, buckets, and funding allocation for each bucket. The goal is then to track every single expense we make, and ensure that they are within the budget parameters we defined. It will let us know on the budget home page if we get close to our allocation; it will also be able to generate reports for us on a monthly basis. There is a `household` field, this field is currently designed to help me track expenses between where I currently live and supporting my mom. These reports will then be able be exportable into some datasheet and buckets will be adjsutable accordingly. 
+
+Straightforward, the goal for this module to calculate everything related to a budget that I will create with my wife. We come up with the budget ourselves, set the parameters, buckets, and funding allocation for each bucket. The goal is then to track every single expense we make, and ensure that they are within the budget parameters we defined. It will let us know on the budget home page if we get close to our allocation; it will also be able to generate reports for us on a monthly basis. There is a `household` field, this field is currently designed to help me track expenses between where I currently live and supporting my mom. These reports will then be able be exportable into some datasheet and buckets will be adjsutable accordingly.
 
 ### TO-DO (Calender)
-As of 2/3/25, this part of the pillar is less defined. I am currently tracking all of my daily tasks on a peice of paper in the morning and writing my data down on a calendar to set up some level of reminders. I can continue to use an application such as Notion, Google calendar and other productivity tools. However, I feel as though these tools are designed specifically for coorporate usage. They are not meant for life tasks, and the categories that come against it. Besides, I'm a cocky software engineer, I can make a tool that works for *ME*. I can also categorize the tasks I do, run a report at the end of the year, see where I have spent the most time doing stuff. 
+
+As of 2/3/25, this part of the pillar is less defined. I am currently tracking all of my daily tasks on a peice of paper in the morning and writing my data down on a calendar to set up some level of reminders. I can continue to use an application such as Notion, Google calendar and other productivity tools. However, I feel as though these tools are designed specifically for coorporate usage. They are not meant for life tasks, and the categories that come against it. Besides, I'm a cocky software engineer, I can make a tool that works for _ME_. I can also categorize the tasks I do, run a report at the end of the year, see where I have spent the most time doing stuff.
 
 ### Home
+
 Another place of ambiguity, but I have some ideas. Currently we wake up and look at messages sent to us from Big Tech giants. These messages are not currated for the lives of humans, they are deisgned to help the capital system grow and keep on turning. I want to look at messages from myself to myself with specifically selected news outlets, with more positivity, the beauty of life and reminders of how we can help each other and the world. I want this home page to be the first thing I look at. Help me realize that with a little bit of effort and not being as distracted. I can create something that I look at every single morning to remind myself what I have the opportunity to do, the budget to spend and a positive message from some of my favorite people in history such as Marcus Aurelius.
 
 ### Future and beyond
+
 Several opportunties lie ahead once I get these 3 things up and going. I think my personal productivity will skyrocket. There's probably going to be several data mining opportunties I'll have. some ideas I'll jot down for later.
 
-1) Pinocchio AI -> My customized AI bot. with enough of my journaled data and thoughts, Pinocchio will help me smell the truth from sources
-2) Medical and Diet Log -> Customized logging dashboard of my blood test/work YoY and the foods I eat to predict how my next blood work will go
-3) Exercise log -> Workout plans and dashboard to help me get really cut, I'm halfway there :wink:. Lets get that full mile in.
-4) Gardener -> I plan on having a garden one day. The sprinkler system will be connected to DASH, dont have enough info on what this looks like yet.
-
+1. Pinocchio AI -> My customized AI bot. with enough of my journaled data and thoughts, Pinocchio will help me smell the truth from sources
+2. Medical and Diet Log -> Customized logging dashboard of my blood test/work YoY and the foods I eat to predict how my next blood work will go
+3. Exercise log -> Workout plans and dashboard to help me get really cut, I'm halfway there :wink:. Lets get that full mile in.
+4. Gardener -> I plan on having a garden one day. The sprinkler system will be connected to DASH, dont have enough info on what this looks like yet.
 
 # Technial SPECs
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 Desined to be a monolithic App with the front-end running on port 3000 and the backend running on 5000
 Database is a Postgres DB (currently a production DB is being hosted on heroku)
 
 ## Future Proof
-1) Create github tasks to self manage tasks and accomplish them
-2) Dockerize the whole application and database so that it is cloud K8s ready
-3) Take it to the cloud and build an immaculately beautiful CICD Pipline
-4) Work through any networking capabilities when taking it on the cloud. 
+
+1. Create github tasks to self manage tasks and accomplish them
+2. Dockerize the whole application and database so that it is cloud K8s ready
+3. Take it to the cloud and build an immaculately beautiful CICD Pipline
+4. Work through any networking capabilities when taking it on the cloud.
 
 ## Available Scripts
 
@@ -77,7 +83,7 @@ This launches Cypress testing suite. These are integration tests to run regressi
 Please run all the test here first before commiting to the main branch to ensure that no functionality has been broken.\
 Write tests of your own for each of the functionalities before commiting in as well.
 
-Eventually this will be integrated in a CI/CD pipeline so that there is no need for manually having to test this out. 
+Eventually this will be integrated in a CI/CD pipeline so that there is no need for manually having to test this out.
 
 ## Learn More
 

--- a/cypress/e2e/budget-page/enter-expense-page.cy.ts
+++ b/cypress/e2e/budget-page/enter-expense-page.cy.ts
@@ -22,6 +22,11 @@ describe('EnterExpensePage', () => {
       'contain',
       'The Expense was successfully saved',
     );
+    
+    // TODO: Cypress currently doesnt insert the value in the DB. 
+    // consider making a parallel testing DB and having cypress insert values into that DB
+
+    // cy.get('[id="expense-table"]').should('contain', 'Vendor Name');
   });
 
   it('should display an error message when the form submission fails -> amount is greater than 10000', () => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "start-backend-prod": "NODE_ENV=production tsc && node dist/server/index.js",
     "start-all-prod": "NODE_ENV=production concurrently \"npm run start\" \"npm run start-backend\"",
     "prettier": "prettier --write .",
-    "test": "jest --detectOpenHandles",
+    "test": "NODE_ENV=development jest --detectOpenHandles",
     "cy:run": "cypress run",
     "cy:open": "cypress open",
     "test:int": "start-server-and-test start-all http://localhost:3000 cy:open",

--- a/src/app/budgeting-page/BudgetHomePage.tsx
+++ b/src/app/budgeting-page/BudgetHomePage.tsx
@@ -13,9 +13,30 @@ const BudgetHomePage: React.FC = () => {
 
   useEffect(() => {
     axios
-      .get('http://localhost:5000/budget/info/all')
+      .get('http://localhost:5000/budget/info/allbucketexpense')
       .then((response) => {
-        setData(response.data);
+        const {data} = response;
+
+        // update rent bucket to have current amount at 3000
+        const testData = data.map((item: BudgetData) => {
+          if (item.bucketname === 'rent') {
+            return {
+              ...item,
+              currentamount: 3000,
+            };
+          }
+
+          if(item.bucketname === 'yogi_activities') {
+            return {
+              ...item,
+              currentamount: 500,
+            }
+          }
+          return item;
+        });
+
+
+        setData(testData);
         setLoading(false);
       })
       .catch((error) => {

--- a/src/app/budgeting-page/budgetComponents/BudgetCategoryComponent.tsx
+++ b/src/app/budgeting-page/budgetComponents/BudgetCategoryComponent.tsx
@@ -4,13 +4,23 @@ import { BudgetComponentProps } from '../types/BudgetCategoryTypes';
 import { transformBucketName, transformCategorytName } from '../utils/helpers';
 
 const BudgetCategoryComponent: React.FC<BudgetComponentProps> = ({ data }) => {
+  const { amount, currentamount} = data;
+  const eightyPercentOfAllocatedAmount = amount * 0.8;
+
+  let cardColor = '#4CAF50';
+  if (currentamount >= eightyPercentOfAllocatedAmount && currentamount < amount) {
+    cardColor = '#FFEB3B';
+  } else if (currentamount > amount) {
+    cardColor = '#F44336';
+  }
+
   const doSomething = () => {
     console.log(`some values: ${JSON.stringify(data)}`);
   };
 
   return (
     <Card>
-      <CardActionArea onClick={() => doSomething()}>
+      <CardActionArea onClick={() => doSomething()} style={{ backgroundColor: cardColor }}>
         <CardContent>
           <Typography variant="h5" component="div">
             {transformBucketName(data.bucketname)}
@@ -23,6 +33,9 @@ const BudgetCategoryComponent: React.FC<BudgetComponentProps> = ({ data }) => {
           </Typography>
           <Typography variant="body2" color="textSecondary">
             Household: {data.household}
+          </Typography>
+          <Typography variant="body2" color="textSecondary">
+            Currently-Using: {data.currentamount}
           </Typography>
         </CardContent>
       </CardActionArea>

--- a/src/app/budgeting-page/budgetComponents/ExpenseComponents/EnterExpensePage.tsx
+++ b/src/app/budgeting-page/budgetComponents/ExpenseComponents/EnterExpensePage.tsx
@@ -11,7 +11,10 @@ import {
 import axios from 'axios';
 import ToastMessage from '../../../customizations/ToastMessages';
 import dayjs, { Dayjs } from 'dayjs';
-import { formatTimestamptzToMMDDYYYY, validateExpense } from '../../utils/helpers';
+import {
+  formatTimestamptzToMMDDYYYY,
+  validateExpense,
+} from '../../utils/helpers';
 import {
   AmountField,
   DateField,
@@ -45,7 +48,9 @@ export const EnterExpensePage: React.FC = () => {
   const fetchExpenses = async () => {
     setLoading(true);
     try {
-      const response = await axios.get('http://localhost:5000/budget/info/allmonthexpense');
+      const response = await axios.get(
+        'http://localhost:5000/budget/info/allmonthexpense',
+      );
       const formattedData = response.data.map((expense: MonthlyExpense) => ({
         ...expense,
         expensedate: formatTimestamptzToMMDDYYYY(expense.expensedate),
@@ -57,7 +62,7 @@ export const EnterExpensePage: React.FC = () => {
       setLoading(false);
     }
   };
-  
+
   useEffect(() => {
     fetchExpenses();
   }, []);
@@ -93,7 +98,7 @@ export const EnterExpensePage: React.FC = () => {
 
     try {
       await postExpense();
-      fetchExpenses(); 
+      fetchExpenses();
     } catch (error) {
       const toastMessageInfo: ToastMessageOptions = {
         message: en.expense.errorMessage,
@@ -115,7 +120,7 @@ export const EnterExpensePage: React.FC = () => {
       message: en.expense.successMessage,
       severity: 'success',
     };
-    
+
     handleToastMessage(toastMessageSeverity);
   };
 

--- a/src/app/budgeting-page/budgetComponents/ExpenseComponents/EnterExpensePage.tsx
+++ b/src/app/budgeting-page/budgetComponents/ExpenseComponents/EnterExpensePage.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, Container, Box, SelectChangeEvent, Grid } from '@mui/material';
 import {
   ExpensePerson,
   ExpenseType,
   ExpenseData,
+  MonthlyExpense,
   ToastSeverityOptions,
   ToastMessageOptions,
 } from '../../types/BudgetCategoryTypes';
@@ -34,6 +35,21 @@ export const EnterExpensePage: React.FC = () => {
     useState<ToastSeverityOptions>('success');
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [date, setDate] = useState<Dayjs>(dayjs(new Date()));
+  const [data, setData] = useState<MonthlyExpense[]>();
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/budget/info/allmonthexpense')
+    .then((response) => {
+      setData(response.data);
+      setLoading(false);
+  })
+  .catch((error) => {
+    setError(error.message);
+    setLoading(false);
+  });
+  }, []);
 
   const handleInputChange =
     (field: keyof ExpenseData) =>

--- a/src/app/budgeting-page/budgetComponents/ExpenseComponents/ExpenseTable.tsx
+++ b/src/app/budgeting-page/budgetComponents/ExpenseComponents/ExpenseTable.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from '@mui/material';
 import { MonthlyExpense } from '../../types/BudgetCategoryTypes';
 
 interface ExpenseTableProps {
@@ -26,7 +34,8 @@ const ExpenseTable: React.FC<ExpenseTableProps> = ({ data }) => {
               <TableCell>{row.amount}</TableCell>
               <TableCell>{row.bucketname}</TableCell>
               <TableCell>{row.description}</TableCell>
-              <TableCell>{row.expensedate}</TableCell> {/* Convert the timestamptz to just MM/DD/YYYY */}
+              <TableCell>{row.expensedate}</TableCell>{' '}
+              {/* Convert the timestamptz to just MM/DD/YYYY */}
               <TableCell>{row.person}</TableCell>
               <TableCell>{row.vendor}</TableCell>
             </TableRow>

--- a/src/app/budgeting-page/budgetComponents/ExpenseComponents/ExpenseTable.tsx
+++ b/src/app/budgeting-page/budgetComponents/ExpenseComponents/ExpenseTable.tsx
@@ -16,7 +16,7 @@ interface ExpenseTableProps {
 
 const ExpenseTable: React.FC<ExpenseTableProps> = ({ data }) => {
   return (
-    <TableContainer component={Paper} style={{ maxHeight: 400 }}>
+    <TableContainer id='expense-table' component={Paper} style={{ maxHeight: 400 }}>
       <Table stickyHeader>
         <TableHead>
           <TableRow>
@@ -31,13 +31,13 @@ const ExpenseTable: React.FC<ExpenseTableProps> = ({ data }) => {
         <TableBody>
           {data?.slice(0, 100).map((row, index) => (
             <TableRow key={index}>
-              <TableCell>{row.amount}</TableCell>
-              <TableCell>{row.bucketname}</TableCell>
-              <TableCell>{row.description}</TableCell>
-              <TableCell>{row.expensedate}</TableCell>{' '}
-              {/* Convert the timestamptz to just MM/DD/YYYY */}
+              <TableCell>{row.expensedate}</TableCell>
               <TableCell>{row.person}</TableCell>
               <TableCell>{row.vendor}</TableCell>
+              <TableCell>{row.bucketname}</TableCell>{' '}
+              {/* Convert the timestamptz to just MM/DD/YYYY */}
+              <TableCell>{row.amount}</TableCell>
+              <TableCell>{row.description}</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/src/app/budgeting-page/budgetComponents/ExpenseComponents/ExpenseTable.tsx
+++ b/src/app/budgeting-page/budgetComponents/ExpenseComponents/ExpenseTable.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
+import { MonthlyExpense } from '../../types/BudgetCategoryTypes';
+
+interface ExpenseTableProps {
+  data?: MonthlyExpense[];
+}
+
+const ExpenseTable: React.FC<ExpenseTableProps> = ({ data }) => {
+  return (
+    <TableContainer component={Paper} style={{ maxHeight: 400 }}>
+      <Table stickyHeader>
+        <TableHead>
+          <TableRow>
+            <TableCell>Expense Date</TableCell>
+            <TableCell>Person</TableCell>
+            <TableCell>Vendor</TableCell>
+            <TableCell>Bucket Name</TableCell>
+            <TableCell>Amount</TableCell>
+            <TableCell>Description</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data?.slice(0, 100).map((row, index) => (
+            <TableRow key={index}>
+              <TableCell>{row.amount}</TableCell>
+              <TableCell>{row.bucketname}</TableCell>
+              <TableCell>{row.description}</TableCell>
+              <TableCell>{row.expensedate}</TableCell> {/* Convert the timestamptz to just MM/DD/YYYY */}
+              <TableCell>{row.person}</TableCell>
+              <TableCell>{row.vendor}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default ExpenseTable;

--- a/src/app/budgeting-page/types/BudgetCategoryTypes.tsx
+++ b/src/app/budgeting-page/types/BudgetCategoryTypes.tsx
@@ -87,4 +87,4 @@ export type MonthlyExpense = {
   amount: number;
   description: string;
   expensedate: string;
-}
+};

--- a/src/app/budgeting-page/types/BudgetCategoryTypes.tsx
+++ b/src/app/budgeting-page/types/BudgetCategoryTypes.tsx
@@ -78,3 +78,13 @@ export const expenseTypeOptions: ExpenseType[] = [
 ];
 
 export const expensePersonOptions: ExpensePerson[] = ['Yogi', 'Riddhi', 'Both'];
+
+export type MonthlyExpense = {
+  id: string;
+  person: string;
+  bucketname: string;
+  vendor: string;
+  amount: number;
+  description: string;
+  expensedate: string;
+}

--- a/src/app/budgeting-page/types/BudgetCategoryTypes.tsx
+++ b/src/app/budgeting-page/types/BudgetCategoryTypes.tsx
@@ -5,6 +5,7 @@ export type BudgetData = {
   bucketname: string;
   amount: number;
   household: string;
+  currentamount: number;
 };
 
 export type BudgetComponentProps = {

--- a/src/app/budgeting-page/utils/helpers.ts
+++ b/src/app/budgeting-page/utils/helpers.ts
@@ -51,4 +51,4 @@ export const validateExpense = (data: ExpenseData): string | null => {
 
 export const formatTimestamptzToMMDDYYYY = (date: string): string => {
   return dayjs(date).format('MM/DD/YYYY');
-}
+};

--- a/src/app/budgeting-page/utils/helpers.ts
+++ b/src/app/budgeting-page/utils/helpers.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { ExpenseData } from '../types/BudgetCategoryTypes';
 
 export const transformBucketName = (bucketname: string): string => {
@@ -47,3 +48,7 @@ export const validateExpense = (data: ExpenseData): string | null => {
 
   return null;
 };
+
+export const formatTimestamptzToMMDDYYYY = (date: string): string => {
+  return dayjs(date).format('MM/DD/YYYY');
+}

--- a/src/server/__tests__/index.test.ts
+++ b/src/server/__tests__/index.test.ts
@@ -1,13 +1,20 @@
 import request from 'supertest';
 import { app, server, db } from '../index';
-import {
-  budgetAllDataInfo,
-  insertData,
-} from '../test_data/budgetData';
+import { budgetAllDataInfo, insertData } from '../test_data/budgetData';
+import { insertExpense } from '../utils/db-operation-helpers';
+import { InsertExpsenseType, InsertResponseId } from '../utils/types';
 
 afterAll(async () => {
-  await db.destroy(); // Close the database connection
-  server.close(); // Close the server connection
+  await db.destroy();
+  server.close();
+});
+
+describe('GET /budget/info/all', () => {
+  it('should retrieve all budget data', async () => {
+    const response = await request(app).get('/budget/info/all');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(budgetAllDataInfo);
+  });
 });
 
 describe('POST /budget/expense', () => {
@@ -17,13 +24,6 @@ describe('POST /budget/expense', () => {
     if (idToDelete) {
       await db('budget_monthly_expenses').where({ id: idToDelete }).del();
     }
-    await db.destroy();
-  });
-
-  it('should retrieve all budget data', async () => {
-    const response = await request(app).get('/budget/info/all');
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual(budgetAllDataInfo);
   });
 
   it('should insert an expense', async () => {
@@ -51,5 +51,35 @@ describe('POST /budget/expense', () => {
       'Invalid requestbody Error: Amount must be greater than 0 or less than 10000',
     );
     expect(response.status).toBe(400);
+  });
+});
+
+describe('GET /budget/info/allmonthexpense', () => {
+  let idToDelete: string;
+  let idToDelete2: string;
+
+  beforeAll(async () => {
+    const insertedData2 = { ...insertData, description: 'February Rent' };
+
+    const response1: InsertResponseId = await insertExpense(
+      insertData as InsertExpsenseType,
+    );
+    const response2: InsertResponseId = await insertExpense(
+      insertedData2 as InsertExpsenseType,
+    );
+
+    idToDelete = response1.id;
+    idToDelete2 = response2.id;
+  });
+
+  afterAll(async () => {
+    await db('budget_monthly_expenses').where({ id: idToDelete }).del();
+    await db('budget_monthly_expenses').where({ id: idToDelete2 }).del();
+  });
+
+  it('should retrieve all monthly expenses', async () => {
+    const response = await request(app).get('/budget/info/allmonthexpense');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveLength(2);
   });
 });

--- a/src/server/__tests__/index.test.ts
+++ b/src/server/__tests__/index.test.ts
@@ -1,8 +1,18 @@
 import request from 'supertest';
 import { app, server, db } from '../index';
 import { budgetAllDataInfo, insertData } from '../test_data/budgetData';
-import { insertExpense } from '../utils/db-operation-helpers';
-import { InsertExpsenseType, InsertResponseId } from '../utils/types';
+import {
+  getAllBudgetData,
+  getAllMonthlyExpense,
+  insertExpense,
+} from '../utils/db-operation-helpers';
+import {
+  BudgetType,
+  InsertExpsenseType,
+  InsertResponseId,
+  MonthlyExpense,
+} from '../utils/types';
+import { calculateBucketExpenses } from '../utils/utils';
 
 afterAll(async () => {
   await db.destroy();
@@ -79,7 +89,17 @@ describe('GET /budget/info/allmonthexpense', () => {
 
   it('should retrieve all monthly expenses', async () => {
     const response = await request(app).get('/budget/info/allmonthexpense');
+    const responsefromDB = await getAllMonthlyExpense();
+
     expect(response.status).toBe(200);
-    expect(response.body).toHaveLength(2);
+    expect(response.body).toHaveLength(responsefromDB.length);
+  });
+});
+
+describe('GET /budget/info/allbucketexpense', () => {
+  it('should retrieve all bucket expenses', async () => {
+    const rawMonthlyData: MonthlyExpense[] = await getAllMonthlyExpense();
+    const allBudgetData: BudgetType[] = await getAllBudgetData();
+    await calculateBucketExpenses(rawMonthlyData, allBudgetData);
   });
 });

--- a/src/server/__tests__/utils.test.ts
+++ b/src/server/__tests__/utils.test.ts
@@ -1,0 +1,109 @@
+import { calculateBucketExpenses, validateExpense } from '../utils/utils';
+import {
+  BudgetType,
+  MonthlyExpense,
+  BudgetTypeWithCurrentAmount,
+  ExpenseRequestBody,
+  InsertExpsenseType,
+} from '../utils/types';
+import {
+  rawMonthlyData,
+  allBudgetData,
+  expectedCaclulatedBudgetExpenses,
+  rawMonthlyDataTest2,
+  expectedTest2,
+  allBudgetDataTest2,
+} from '../test_data/utilsTestData';
+import { ExpenseAmountMinAndMaxError } from '../utils/consts';
+
+describe('calculateBucketExpenses', () => {
+  it('should calculate the current amount spent for each bucket', async () => {
+    const result = await calculateBucketExpenses(rawMonthlyData, allBudgetData);
+    expect(result).toEqual(expectedCaclulatedBudgetExpenses);
+  });
+
+  it('should return zero current amount for buckets with no expenses', async () => {
+    const result = await calculateBucketExpenses(rawMonthlyDataTest2, allBudgetDataTest2);
+    expect(result).toEqual(expectedTest2);
+  });
+
+  it('should handle empty rawMonthlyData', async () => {
+    const emptyRawMonthlyData: MonthlyExpense[] = [];
+    const expected: BudgetTypeWithCurrentAmount[] = [
+      {
+        bucketname: 'rent',
+        amount: 2000,
+        currentamount: 0,
+        category: 'housing',
+        household: 'household',
+        id: '1',
+      },
+      {
+        bucketname: 'groceries',
+        amount: 300,
+        currentamount: 0,
+        category: 'food',
+        household: 'household',
+        id: '2',
+      },
+    ];
+
+    const result = await calculateBucketExpenses(emptyRawMonthlyData, allBudgetDataTest2);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('validateExpense', () => {
+  it('should validate and return the expense object', async () => {
+    const reqBody: ExpenseRequestBody = {
+      person: 'John Doe',
+      bucketname: 'groceries',
+      vendor: 'Walmart',
+      amount: 100,
+      description: 'Weekly groceries',
+      date: '2021-01-01',
+    };
+
+    const expected: InsertExpsenseType = {
+      person: 'John Doe',
+      bucketname: 'groceries',
+      vendor: 'Walmart',
+      amount: 100,
+      description: 'Weekly groceries',
+      expensedate: '2021-01-01',
+    };
+
+    const result = await validateExpense(reqBody);
+    expect(result).toEqual(expected);
+  });
+
+  it('should throw an error if amount is missing or invalid', async () => {
+    const reqBody: ExpenseRequestBody = {
+      person: 'John Doe',
+      bucketname: 'groceries',
+      vendor: 'Walmart',
+      amount: -100,
+      description: 'Weekly groceries',
+      date: '2021-01-01',
+    };
+
+    await expect(validateExpense(reqBody)).rejects.toThrow(
+      ExpenseAmountMinAndMaxError,
+    );
+  });
+
+  it('should throw an error if required fields are missing', async () => {
+    const reqBody: ExpenseRequestBody = {
+      person: '',
+      bucketname: 'groceries',
+      vendor: 'Walmart',
+      amount: 100,
+      description: 'Weekly groceries',
+      date: '2021-01-01',
+    };
+
+    await expect(validateExpense(reqBody)).rejects.toThrow(
+      'Missing required fields person: , bucketname: groceries, vendor: Walmart',
+    );
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,8 +5,12 @@ import db from './utils/db';
 import { validateExpense } from './utils/utils';
 import logger from './utils/logger';
 
-import { InsertExpsenseType, BudgetType } from './utils/types';
-import { getAllBudgetData, insertExpense } from './utils/db-operation-helpers';
+import { InsertExpsenseType, BudgetType, MonthlyExpense } from './utils/types';
+import {
+  getAllBudgetData,
+  insertExpense,
+  getAllMonthlyExpense,
+} from './utils/db-operation-helpers';
 
 // Initialize express app
 const app = express();
@@ -15,28 +19,41 @@ const app = express();
 app.use(bodyParser.json());
 app.use(cors());
 
-// GET: Create an endpoint that will retrieve a budget plan for a specific allocation
+// GET: An endpoint that will retrieve a budget plan for a specific allocation
 app.get('/budget/info/all', async (req, res) => {
   try {
     const data: BudgetType[] = await getAllBudgetData();
     res.json(data);
-  } catch (err) {
-    res.status(500).json({ error: 'Internal Server Error' });
+  } catch (error) {
+    logger.error(`Error fetching budget data: ${error}`);
+    res.status(500).json({ error: `Internal Server Error ${error}` });
   }
 });
 
-app.get('/budget/info/monthexpense', async (req, res) => {
+// GET: An Endpoint to get all of the expenses for the current month
+app.get('/budget/info/allmonthexpense', async (req, res) => {
   try {
-    const data = await db.raw(`
-      SELECT * FROM 
-      budget_monthly_expenses 
-      WHERE expense_date >= date_trunc('month', CURRENT_DATE)
-      AND expense_date < date_trunc('month', CURRENT_DATE) + INTERVAL '1 month'
-      ORDER BY expense_date DESC`);
-    console.log('datastructure', data.rows);
-    return data.rows;
-  } catch (error) {}
+    const data: MonthlyExpense[] = await getAllMonthlyExpense();
+
+    res.json(data);
+  } catch (error) {
+    logger.error(`Error fetching monthly expense data: ${error}`);
+    res.status(500).json({ error: `Internal Server Error ${error}` });
+  }
 });
+
+// GET: An endpoint for seeing how much money is left in all buckets
+// Going to do this on the frontend for now
+// app.get('budget/info/allbucketexpense', async (req, res) => {
+//   try {
+//     const rawMonthlyData: MonthlyExpense[] = await getAllMonthlyExpense();
+//     const data = await calculateBucketExpenses(rawMonthlyData);
+//     res.json(data);
+//   } catch (error) {
+//     logger.error(`Error fetching monthly expense data: ${error}`);
+//     res.status(500).json({ error: `Internal Server Error ${error}` });
+//   }
+// });
 
 // POST: Create an endpoint that will add a new expense to the allocated bucket in the budget plan
 app.post('/budget/expense', async (req, res) => {
@@ -54,11 +71,5 @@ const port = process.env.PORT || 5000;
 const server = app.listen(port, () => {
   logger.info(`Server running on port ${port}`);
 });
-
-// if (process.env.NODE_ENV !== 'test') {
-//   app.listen(port, () =>
-//     console.log(`Server running on port ${port}, http://localhost:${port}`),
-//   );
-// }
 
 export { app, server, db };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -20,6 +20,7 @@ app.use(bodyParser.json());
 app.use(cors());
 
 // GET: An endpoint that will retrieve a budget plan for a specific allocation
+// TODO: THIS ENDPOINT MIGHT NOT BE NEEDED ANYMORE IN CASE allbucketexpense IS IMPLEMENTED
 app.get('/budget/info/all', async (req, res) => {
   try {
     const data: BudgetType[] = await getAllBudgetData();
@@ -43,7 +44,7 @@ app.get('/budget/info/allmonthexpense', async (req, res) => {
 });
 
 // GET: An endpoint for seeing how much money is left in all buckets
-app.get('budget/info/allbucketexpense', async (req, res) => {
+app.get('/budget/info/allbucketexpense', async (req, res) => {
   try {
     const rawMonthlyData: MonthlyExpense[] = await getAllMonthlyExpense();
     const allBudgetData: BudgetType[] = await getAllBudgetData();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,14 +2,14 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import db from './utils/db';
-import { validateExpense } from './utils/utils';
+import { validateExpense, calculateBucketExpenses } from './utils/utils';
 import logger from './utils/logger';
 
 import { InsertExpsenseType, BudgetType, MonthlyExpense } from './utils/types';
 import {
   getAllBudgetData,
-  insertExpense,
   getAllMonthlyExpense,
+  insertExpense,
 } from './utils/db-operation-helpers';
 
 // Initialize express app
@@ -43,17 +43,18 @@ app.get('/budget/info/allmonthexpense', async (req, res) => {
 });
 
 // GET: An endpoint for seeing how much money is left in all buckets
-// Going to do this on the frontend for now
-// app.get('budget/info/allbucketexpense', async (req, res) => {
-//   try {
-//     const rawMonthlyData: MonthlyExpense[] = await getAllMonthlyExpense();
-//     const data = await calculateBucketExpenses(rawMonthlyData);
-//     res.json(data);
-//   } catch (error) {
-//     logger.error(`Error fetching monthly expense data: ${error}`);
-//     res.status(500).json({ error: `Internal Server Error ${error}` });
-//   }
-// });
+app.get('budget/info/allbucketexpense', async (req, res) => {
+  try {
+    const rawMonthlyData: MonthlyExpense[] = await getAllMonthlyExpense();
+    const allBudgetData: BudgetType[] = await getAllBudgetData();
+
+    const data = await calculateBucketExpenses(rawMonthlyData, allBudgetData);
+    res.json(data);
+  } catch (error) {
+    logger.error(`Error fetching monthly expense data: ${error}`);
+    res.status(500).json({ error: `Internal Server Error ${error}` });
+  }
+});
 
 // POST: Create an endpoint that will add a new expense to the allocated bucket in the budget plan
 app.post('/budget/expense', async (req, res) => {

--- a/src/server/test_data/budgetData.ts
+++ b/src/server/test_data/budgetData.ts
@@ -1,105 +1,105 @@
 // NEEDS
 export const rentBudgetData = {
   category: 'needs',
-  bucketName: 'rent',
+  bucketname: 'rent',
   budget: 3200,
 };
 
 export const electricBudgetData = {
   category: 'needs',
-  bucketName: 'electric',
+  bucketname: 'electric',
   budget: 140,
 };
 
 export const internetBudgetData = {
   category: 'needs',
-  bucketName: 'internet',
+  bucketname: 'internet',
   budget: 70,
 };
 
 export const parcelBudgetData = {
   category: 'needs',
-  bucketName: 'parcel',
+  bucketname: 'parcel',
   budget: 5,
 };
 
 export const groceriesBudgetData = {
   category: 'needs',
-  bucketName: 'groceries',
+  bucketname: 'groceries',
   budget: 580,
 };
 
 export const gasBudgetData = {
   category: 'needs',
-  bucketName: 'gas',
+  bucketname: 'gas',
   budget: 150,
 };
 
 export const therapyBudgetData = {
   category: 'needs',
-  bucketName: 'therapy',
+  bucketname: 'therapy',
   budget: 125,
 };
 
 export const homeSuppliesBudgetData = {
   category: 'needs',
-  bucketName: 'home supplies',
+  bucketname: 'home supplies',
   budget: 150,
 };
 
 // WANTS
 export const netflixBudgetData = {
   category: 'wants',
-  bucketName: 'netflix',
+  bucketname: 'netflix',
   budget: 17, // rounded up to the nearest dollar
 };
 
 export const spotifyBudgetData = {
   category: 'wants',
-  bucketName: 'spotify',
+  bucketname: 'spotify',
   budget: 13, // rounded up to the nearest dollar
 };
 
 export const dateNightBudgetData = {
   category: 'wants',
-  bucketName: 'date night',
+  bucketname: 'date night',
   budget: 120,
 };
 
 export const vacationBudgetData = {
   category: 'wants',
-  bucketName: 'vacation',
+  bucketname: 'vacation',
   budget: 1000,
 };
 
 export const goingOutBudgetData = {
   category: 'wants',
-  bucketName: 'going out',
+  bucketname: 'going out',
   budget: 200,
 };
 
 export const giftsBudgetData = {
   category: 'wants',
-  bucketName: 'gifts',
+  bucketname: 'gifts',
   budget: 100,
 };
 
 export const yogiActivitiesBudgetData = {
   category: 'wants',
-  bucketName: 'yogi activities',
+  bucketname: 'yogi activities',
   budget: 200,
 };
 
 export const clothesBudgetData = {
   category: 'wants',
-  bucketName: 'clothes',
+  bucketname: 'clothes',
   budget: 200,
 };
 
 // SAVINGS
 export const savingsFundBudgetData = {
   category: 'savings',
-  bucketName: 'savings fund',
+  bucketname: 'savings fund',
   budget: 5500,
 };
 

--- a/src/server/test_data/budgetData.ts
+++ b/src/server/test_data/budgetData.ts
@@ -108,7 +108,7 @@ export const insertData = {
   person: 'Yogi',
   bucketname: 'rent',
   vendor: 'Domus',
-  amount: '3200',
+  amount: 3200,
   description: 'January Rent',
 };
 
@@ -119,118 +119,118 @@ export const budgetAllDataInfo = [
     category: 'needs',
     bucketname: 'rent',
     amount: 3200,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '8c0cc1c3-4e87-4223-8ce3-e721ff9417e7',
     category: 'needs',
     bucketname: 'electric',
     amount: 140,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: 'eea022f6-e307-4eaa-9ccf-dcd7f19b3717',
     category: 'needs',
     bucketname: 'parcel',
     amount: 5,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '6a106196-e0be-46d9-84cb-2e631c2504cf',
     category: 'needs',
     bucketname: 'groceries',
     amount: 580,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '4d76327b-b366-4f6b-b9ae-fb018ca4dddb',
     category: 'needs',
     bucketname: 'gas',
     amount: 150,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '76c046bb-f192-4148-9eda-d714c0c067f9',
     category: 'needs',
     bucketname: 'therapy',
     amount: 125,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: 'bfb595cc-f8a2-4914-bd45-034526f205b1',
     category: 'needs',
     bucketname: 'house_supplies',
     amount: 150,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: 'a13af0ba-3418-4c9a-9840-a0136c3d09fc',
     category: 'wants',
     bucketname: 'netflix',
     amount: 17,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '71cd8515-a587-4e40-8435-0c4381f65802',
     category: 'wants',
     bucketname: 'spotify',
     amount: 13,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: 'c2239be8-3793-42da-9d9e-ea980ccca2a1',
     category: 'wants',
     bucketname: 'date_night',
     amount: 120,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '967aec6e-147e-42eb-a616-effa7a46d902',
     category: 'wants',
     bucketname: 'vacation',
     amount: 1000,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '94300054-ef4c-43de-82d8-d03de6402d50',
     category: 'wants',
     bucketname: 'going_out_yogi',
     amount: 200,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: 'c4dd9e5b-7b80-41c6-b6e9-1525dc8925cc',
     category: 'wants',
     bucketname: 'gifts',
     amount: 166,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '744c5921-5430-4725-a812-1de76b8a0ee5',
     category: 'wants',
     bucketname: 'yogi_activities',
     amount: 200,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: 'a0bc7722-ab7d-4925-934d-ae29005ca823',
     category: 'wants',
     bucketname: 'clothes',
     amount: 200,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '26a0d0aa-5f81-4902-8372-cb4219e66a80',
     category: 'savings',
     bucketname: 'savings_chase_2112',
     amount: 5500,
-    household: 'domus'
+    household: 'domus',
   },
   {
     id: '7a24bf63-aaee-45a1-9bd1-072b8d346e63',
     category: 'needs',
     bucketname: 'internet',
     amount: 70,
-    household: 'domus'
-  }
+    household: 'domus',
+  },
 ];

--- a/src/server/test_data/utilsTestData.ts
+++ b/src/server/test_data/utilsTestData.ts
@@ -1,0 +1,144 @@
+import {
+  BudgetType,
+  BudgetTypeWithCurrentAmount,
+  MonthlyExpense,
+} from '../utils/types';
+
+export const rawMonthlyData: MonthlyExpense[] = [
+  {
+    bucketname: 'rent',
+    amount: 1000,
+    description: 'rent',
+    expensedate: '2021-01-01',
+    id: '1',
+    person: 'person',
+    vendor: 'vendor',
+  },
+  {
+    bucketname: 'groceries',
+    amount: 200,
+    description: 'groceries',
+    expensedate: '2021-01-01',
+    id: '2',
+    person: 'person',
+    vendor: 'vendor',
+  },
+  {
+    bucketname: 'rent',
+    amount: 500,
+    description: 'rent',
+    expensedate: '2021-01-01',
+    id: '3',
+    person: 'person',
+    vendor: 'vendor',
+  },
+  {
+    bucketname: 'entertainment',
+    amount: 150,
+    description: 'entertainment',
+    expensedate: '2021-01-01',
+    id: '4',
+    person: 'person',
+    vendor: 'vendor',
+  },
+];
+
+export const allBudgetData: BudgetType[] = [
+  {
+    bucketname: 'rent',
+    amount: 2000,
+    category: 'housing',
+    household: 'household',
+    id: '1',
+  },
+  {
+    bucketname: 'groceries',
+    amount: 300,
+    category: 'food',
+    household: 'household',
+    id: '2',
+  },
+  {
+    bucketname: 'entertainment',
+    amount: 200,
+    category: 'fun',
+    household: 'household',
+    id: '3',
+  },
+];
+
+export const expectedCaclulatedBudgetExpenses: BudgetTypeWithCurrentAmount[] = [
+  {
+    bucketname: 'rent',
+    amount: 2000,
+    currentamount: 1500,
+    category: 'housing',
+    household: 'household',
+    id: '1',
+  },
+  {
+    bucketname: 'groceries',
+    amount: 300,
+    currentamount: 200,
+    category: 'food',
+    household: 'household',
+    id: '2',
+  },
+  {
+    bucketname: 'entertainment',
+    amount: 200,
+    currentamount: 150,
+    category: 'fun',
+    household: 'household',
+    id: '3',
+  },
+];
+
+// test 2 data
+export const rawMonthlyDataTest2: MonthlyExpense[] = [
+    {
+      bucketname: 'rent',
+      amount: 1000,
+      description: 'rent',
+      expensedate: '2021-01-01',
+      id: '1',
+      person: 'person',
+      vendor: 'vendor',
+    },
+  ];
+
+ export const allBudgetDataTest2: BudgetType[] = [
+    {
+      bucketname: 'rent',
+      amount: 2000,
+      category: 'housing',
+      household: 'household',
+      id: '1',
+    },
+    {
+      bucketname: 'groceries',
+      amount: 300,
+      category: 'food',
+      household: 'household',
+      id: '2',
+    },
+  ];
+
+ export const expectedTest2: BudgetTypeWithCurrentAmount[] = [
+    {
+      bucketname: 'rent',
+      amount: 2000,
+      currentamount: 1000,
+      category: 'housing',
+      household: 'household',
+      id: '1',
+    },
+    {
+      bucketname: 'groceries',
+      amount: 300,
+      currentamount: 0,
+      category: 'food',
+      household: 'household',
+      id: '2',
+    },
+  ];

--- a/src/server/utils/consts.ts
+++ b/src/server/utils/consts.ts
@@ -1,2 +1,5 @@
 export const ExpenseAmountMinAndMaxError =
   'Amount must be greater than 0 or less than 10000';
+
+export const ErrorFetchingBudgetData = 'Error fetching budget data';
+export const ErrorInsertingExpense = 'Error inserting expense';

--- a/src/server/utils/db-operation-helpers.ts
+++ b/src/server/utils/db-operation-helpers.ts
@@ -23,7 +23,6 @@ export const getAllBudgetData = async (): Promise<BudgetType[]> => {
 export const insertExpense = async (
   expense: InsertExpsenseType,
 ): Promise<InsertResponseId> => {
-  // move this out of the try catch
   let insertObj: InsertExpsenseType = {
     person: expense.person,
     bucketname: expense.bucketname,

--- a/src/server/utils/db-operation-helpers.ts
+++ b/src/server/utils/db-operation-helpers.ts
@@ -1,42 +1,76 @@
 import db from './db';
-import { BudgetType, InsertExpsenseType } from './types';
+import logger from './logger';
+import {
+  BudgetType,
+  InsertExpsenseType,
+  InsertResponseId,
+  MonthlyExpense,
+} from './types';
+import { ErrorFetchingBudgetData, ErrorInsertingExpense } from './consts';
 
 export const getAllBudgetData = async (): Promise<BudgetType[]> => {
   try {
     const result = await db('budget_monthly_allocation').select('*');
+    logger.info(`Fetching all budget data ${result}`);
 
     return result;
   } catch (err) {
-    console.error('Error fetching budget data:', err);
+    logger.error(`${ErrorFetchingBudgetData} ${err}`);
     throw err;
   }
 };
 
 export const insertExpense = async (
   expense: InsertExpsenseType,
-): Promise<number> => {
-  try {
-    let insertObj: InsertExpsenseType = {
-      person: expense.person,
-      bucketname: expense.bucketname,
-      vendor: expense.vendor,
-      amount: expense.amount,
-      description: expense.description,
+): Promise<InsertResponseId> => {
+  // move this out of the try catch
+  let insertObj: InsertExpsenseType = {
+    person: expense.person,
+    bucketname: expense.bucketname,
+    vendor: expense.vendor,
+    amount: expense.amount,
+    description: expense.description,
+  };
+
+  if (expense.expensedate) {
+    insertObj = {
+      ...insertObj,
+      expensedate: expense.expensedate,
     };
-
-    if (expense.expensedate) {
-      insertObj = {
-        ...insertObj,
-        expensedate: expense.expensedate,
-      };
-    }
-
+  }
+  try {
     const result = await db('budget_monthly_expenses')
       .insert(insertObj)
-      .returning('id');
+      .returning('id')
+      .whereNull('deletedat');
+
+    logger.info(`Inserted expense ${result[0]}`);
+
     return result[0];
   } catch (err) {
-    console.error('Error inserting expense:', err);
+    logger.error(`${ErrorInsertingExpense} ${err}`);
     throw err;
+  }
+};
+
+export const getAllMonthlyExpense = async (): Promise<MonthlyExpense[]> => {
+  try {
+    const result: MonthlyExpense[] = await db('budget_monthly_expenses')
+      .select('*')
+      .where('expensedate', '>=', db.raw("date_trunc('month', CURRENT_DATE)"))
+      .where(
+        'expensedate',
+        '<',
+        db.raw("date_trunc('month', CURRENT_DATE) + INTERVAL '1 month'"),
+      )
+      .whereNull('deletedat')
+      .orderBy('expensedate', 'desc');
+
+    logger.info(`Fetching all monthly expenses ${result}`);
+
+    return result;
+  } catch (error) {
+    logger.error(`${ErrorFetchingBudgetData} ${error}`);
+    throw error;
   }
 };

--- a/src/server/utils/types.ts
+++ b/src/server/utils/types.ts
@@ -24,3 +24,17 @@ export type InsertExpsenseType = {
   description?: string;
   expensedate?: string;
 };
+
+export type MonthlyExpense = {
+  id: string;
+  person: string;
+  bucketname: string;
+  vendor: string;
+  amount: number;
+  description: string;
+  expensedate: string;
+};
+
+export type InsertResponseId = {
+  id: string;
+};

--- a/src/server/utils/types.ts
+++ b/src/server/utils/types.ts
@@ -11,9 +11,13 @@ export interface ExpenseRequestBody {
 export type BudgetType = {
   id: string;
   category: string;
-  bucketName: string;
+  bucketname: string;
   amount: number;
   household: string;
+};
+
+export type BudgetTypeWithCurrentAmount = BudgetType & {
+  currentamount: number;
 };
 
 export type InsertExpsenseType = {
@@ -38,3 +42,5 @@ export type MonthlyExpense = {
 export type InsertResponseId = {
   id: string;
 };
+
+export type BucketExpenseMap = Map<string, number>;


### PR DESCRIPTION
Adding:
* Backend endpoint to retrieve all expenses data by the month and sorted ✅
* Updates to the EnterExpense page to display all of the expense underneath in a table format ✅ 
* Endpoint that calculates remaining budget for each bucket ✅ 
* Updates to the Budget main page to show the new currently used budget field ✅ 

Tests:
* Need to include a cypress test for adding a new record and having that show up on the table correctly [WILL DO LATER due to cypress/DB limitations]
* Need to update test /budget/info/allmonthexpense -> to be more dynamic with checking rows returned ✅ 