### PR TITLE
Add real end-to-end Cypress test for expense create/delete flow

### DIFF
--- a/cypress/e2e/budget-page/budget.cy.ts
+++ b/cypress/e2e/budget-page/budget.cy.ts
@@ -6,6 +6,6 @@ describe('Navigation', () => {
     cy.url().should('include', '/budget');
 
     cy.contains('[id="budget-card"]', 'Date Night').click();
-    cy.url().should('include', '/budget/details/date_night');
+    cy.url().should('match', /\/budget\/details\/\d{4}-\d{2}\/date_night$/);
   });
 });

--- a/cypress/e2e/budget-page/expense-crud.cy.ts
+++ b/cypress/e2e/budget-page/expense-crud.cy.ts
@@ -33,8 +33,10 @@ describe('Expense CRUD (real backend + database)', () => {
         },
       );
 
+      cy.intercept('GET', '**/budget/info/allmonthexpense').as('getExpenses');
+
       cy.reload();
+      cy.wait('@getExpenses');
       cy.get('[id="expense-table"]').should('not.contain', vendor);
-    });
   });
 });

--- a/cypress/e2e/budget-page/expense-crud.cy.ts
+++ b/cypress/e2e/budget-page/expense-crud.cy.ts
@@ -1,0 +1,40 @@
+describe('Expense CRUD (real backend + database)', () => {
+  it('creates an expense, verifies it was saved, then removes it from the test database', () => {
+    const vendor = `Cypress Test Vendor ${Date.now()}`;
+
+    cy.visit('http://localhost:3000/budget/enter-expense');
+
+    cy.get('[id="amount-field"]').type('42');
+    cy.get('[id="vendor-field"]').type(vendor);
+    cy.get('[id="type-field"]').click();
+    cy.get('li[data-value="groceries"]').click();
+    cy.get('[id="description-field"]').type('Created by Cypress E2E test');
+
+    cy.intercept('POST', '**/budget/expense').as('postExpense');
+    cy.get('[id="submit-button"]').click();
+
+    cy.wait('@postExpense').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const expenseId = response?.body.id;
+      expect(expenseId).to.be.a('string');
+
+      // Verify it was created: it shows up in the expense table for the current month.
+      cy.get('[id="expense-table"]')
+        .should('contain', vendor)
+        .and('contain', 'groceries');
+      cy.get('[id="toast-message"]').should('contain', expenseId);
+
+      // Clean up: delete the expense we created from the test database via the real API,
+      // then confirm it no longer appears after a refetch.
+      cy.request('DELETE', `http://localhost:5000/budget/expense/${expenseId}`).then(
+        (deleteResponse) => {
+          expect(deleteResponse.status).to.eq(200);
+        },
+      );
+
+      cy.reload();
+      cy.get('[id="expense-table"]').should('not.contain', vendor);
+    });
+  });
+});

--- a/src/app/budgeting-page/budget-components/ExpenseComponents/EnterExpensePage.tsx
+++ b/src/app/budgeting-page/budget-components/ExpenseComponents/EnterExpensePage.tsx
@@ -171,7 +171,7 @@ export const EnterExpensePage: React.FC = () => {
       data,
     );
     const toastMessageSeverity: ToastMessageOptions = {
-      message: `en.expense.successMessage ${response.data.id}`,
+      message: `${en.expense.successMessage} ${response.data.id}`,
       severity: 'success',
     };
 

--- a/src/app/budgeting-page/budget-components/ExpenseComponents/ExpenseSubComponents.tsx
+++ b/src/app/budgeting-page/budget-components/ExpenseComponents/ExpenseSubComponents.tsx
@@ -69,7 +69,7 @@ type TypeFieldProps = {
 export const TypeField: React.FC<TypeFieldProps> = ({ type, onChange }) => (
   <FormControl variant="outlined" fullWidth>
     <InputLabel>Type</InputLabel>
-    <Select value={type} onChange={onChange} label="Type">
+    <Select id="type-field" value={type} onChange={onChange} label="Type">
       {expenseTypeOptions.map((option) => (
         <MenuItem key={option} value={option}>
           {transformBucketName(option)}


### PR DESCRIPTION
Adds a Cypress test that exercises the enter-expense form against the real backend and database (create -> verify -> delete), instead of the existing mocked-network test. Along the way:

- Gives the Type select a stable id (type-field) so it can be driven in tests, matching the other form fields.
- Fixes the success toast on expense creation, which rendered the literal string "en.expense.successMessage" instead of the translated copy.
- Fixes a stale budget.cy.ts assertion expecting /budget/details/date_night; the route now includes the month (/budget/details/:YYYYMM/:bucketname).