### PR TITLE
complete working word of the day from wordnik

### DIFF
--- a/cypress/e2e/home-page/word-of-the-day.cy.ts
+++ b/cypress/e2e/home-page/word-of-the-day.cy.ts
@@ -1,0 +1,28 @@
+describe('Word of the Day (real backend + database)', () => {
+  it('shows a word of the day on the home page and keeps serving the same word on reload', () => {
+    cy.intercept('GET', '**/daily-word').as('getDailyWord');
+
+    cy.visit('http://localhost:3000/');
+
+    cy.wait('@getDailyWord').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+
+      const { word } = response?.body;
+      expect(word).to.be.a('string').and.not.be.empty;
+
+      cy.get('[id="word-of-the-day"]').should('contain', word);
+
+      // Reloading should re-serve the same cached word for today rather than
+      // fetching a new one, proving the daily cache is actually being read.
+      cy.intercept('GET', '**/daily-word').as('getDailyWordAgain');
+      cy.reload();
+
+      cy.wait('@getDailyWordAgain').then(({ response: secondResponse }) => {
+        expect(secondResponse?.statusCode).to.eq(200);
+        expect(secondResponse?.body.word).to.eq(word);
+      });
+
+      cy.get('[id="word-of-the-day"]').should('contain', word);
+    });
+  });
+});

--- a/db/migrations/20260721152704_create_daily_word_tables.js
+++ b/db/migrations/20260721152704_create_daily_word_tables.js
@@ -1,0 +1,101 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('daily_words', (table) => {
+    table.bigIncrements('id').primary();
+
+    table.string('wordnik_id', 64).notNullable().unique();
+    table.string('word', 255).notNullable();
+
+    table.date('display_date').notNullable().unique();
+    table.timestamp('publish_date', { useTz: true }).notNullable();
+
+    table.string('provider_name', 100).notNullable();
+    table.integer('provider_id').nullable();
+
+    table.text('note').nullable();
+    table.text('html_extra').nullable();
+
+    table.jsonb('raw_payload').notNullable();
+
+    table
+      .timestamp('fetched_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+
+    table
+      .timestamp('created_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+
+    table
+      .timestamp('updated_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+
+    table.index('word');
+  });
+
+  await knex.schema.createTable('daily_word_definitions', (table) => {
+    table.bigIncrements('id').primary();
+
+    table
+      .bigInteger('daily_word_id')
+      .notNullable()
+      .references('id')
+      .inTable('daily_words')
+      .onDelete('CASCADE');
+
+    table.text('definition').notNullable();
+    table.string('part_of_speech', 100).nullable();
+    table.string('source', 100).nullable();
+    table.text('note').nullable();
+
+    table.integer('display_order').notNullable();
+
+    table
+      .timestamp('created_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+
+    table.unique(['daily_word_id', 'display_order']);
+    table.index('daily_word_id');
+    table.index('part_of_speech');
+  });
+
+  await knex.schema.createTable('daily_word_examples', (table) => {
+    table.bigIncrements('id').primary();
+
+    table
+      .bigInteger('daily_word_id')
+      .notNullable()
+      .references('id')
+      .inTable('daily_words')
+      .onDelete('CASCADE');
+
+    table.bigInteger('wordnik_example_id').nullable();
+    table.text('example_text').notNullable();
+    table.text('title').nullable();
+    table.text('source_url').nullable();
+
+    table.integer('display_order').notNullable();
+
+    table
+      .timestamp('created_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+
+    table.unique(['daily_word_id', 'display_order']);
+    table.index('daily_word_id');
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('daily_word_examples');
+  await knex.schema.dropTableIfExists('daily_word_definitions');
+  await knex.schema.dropTableIfExists('daily_words');
+};

--- a/src/__tests__/daily-word-controller.test.ts
+++ b/src/__tests__/daily-word-controller.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import { db, server, app } from '../server';
+import { getWordOfTheDayService } from '../server/services/dailyWordService';
+import { DailyWord } from '../server/utils/types';
+
+jest.mock('../server/services/dailyWordService', () => ({
+  getWordOfTheDayService: jest.fn(),
+}));
+
+afterAll(async () => {
+  await db.destroy();
+  server.close();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+const dailyWord: DailyWord = {
+  id: '1',
+  wordnikId: 'wordnik-1',
+  word: 'chandelle',
+  displayDate: '2026-07-21',
+  publishDate: '2026-07-21T03:00:00.000Z',
+  providerName: 'wordnik',
+  providerId: 711,
+  note: null,
+  htmlExtra: null,
+  definitions: [],
+  examples: [],
+};
+
+describe('GET /daily-word', () => {
+  it('should return the word of the day', async () => {
+    (getWordOfTheDayService as jest.Mock).mockResolvedValue(dailyWord);
+
+    const response = await request(app).get('/daily-word');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(dailyWord);
+  });
+
+  it('should return a 500 error if the service throws', async () => {
+    (getWordOfTheDayService as jest.Mock).mockRejectedValue(
+      new Error('Wordnik is down'),
+    );
+
+    const response = await request(app).get('/daily-word');
+
+    expect(response.status).toBe(500);
+    expect(response.body.error).toContain('Wordnik is down');
+  });
+});

--- a/src/__tests__/daily-word-db-operations.test.ts
+++ b/src/__tests__/daily-word-db-operations.test.ts
@@ -1,0 +1,113 @@
+import { db, server } from '../server';
+import {
+  getDailyWordByDisplayDate,
+  insertDailyWord,
+} from '../server/utils/db-operation-helpers';
+import { WordnikWordOfTheDayResponse } from '../server/utils/types';
+
+describe('daily word DB operations', () => {
+  const displayDate = '2099-01-01';
+  const noRowDisplayDate = '2099-12-31';
+
+  const fixturePayload: WordnikWordOfTheDayResponse = {
+    _id: 'test-wordnik-id-chandelle',
+    word: 'chandelle',
+    publishDate: '2099-01-01T03:00:00.000Z',
+    contentProvider: { name: 'wordnik', id: 711 },
+    note: 'A test note about chandelle.',
+    htmlExtra: null,
+    pdd: displayDate,
+    definitions: [
+      {
+        text: 'A sudden, steep climbing turn of an aircraft.',
+        partOfSpeech: 'noun',
+        source: 'ahd-legacy',
+        note: null,
+      },
+      {
+        text: 'To execute a chandelle.',
+        partOfSpeech: 'verb-intransitive',
+        source: 'ahd-legacy',
+        note: null,
+      },
+    ],
+    examples: [
+      {
+        id: 1039329183,
+        url: 'https://books.google.com/books/about/On_Yankee_Station.html',
+        text: 'Recovering on a reciprocal heading, the Spad pilot added power, climbing into a chandelle.',
+        title: 'On Yankee Station',
+      },
+      {
+        id: 706250586,
+        url: 'http://books.simonandschuster.com/9781439140048',
+        text: 'She was either using too much rudder in her chandelle maneuvers.',
+        title: 'Silver Wings, Santiago Blue',
+      },
+    ],
+  };
+
+  let insertedDailyWordId: string;
+
+  afterAll(async () => {
+    if (insertedDailyWordId) {
+      // daily_word_definitions and daily_word_examples cascade-delete on the FK
+      await db('daily_words').where({ id: insertedDailyWordId }).del();
+    }
+
+    await db.destroy();
+    server.close();
+  });
+
+  it('should insert a daily word with its definitions and examples', async () => {
+    const result = await insertDailyWord(fixturePayload, displayDate);
+    insertedDailyWordId = result.id;
+
+    expect(result.word).toBe('chandelle');
+    expect(result.wordnikId).toBe('test-wordnik-id-chandelle');
+    expect(result.displayDate).toBe(displayDate);
+    expect(result.providerName).toBe('wordnik');
+    expect(result.providerId).toBe(711);
+
+    expect(result.definitions).toHaveLength(2);
+    expect(result.definitions[0]).toMatchObject({
+      definition: 'A sudden, steep climbing turn of an aircraft.',
+      partOfSpeech: 'noun',
+      displayOrder: 0,
+    });
+    expect(result.definitions[1]).toMatchObject({
+      definition: 'To execute a chandelle.',
+      partOfSpeech: 'verb-intransitive',
+      displayOrder: 1,
+    });
+
+    expect(result.examples).toHaveLength(2);
+    expect(result.examples[0]).toMatchObject({
+      exampleText:
+        'Recovering on a reciprocal heading, the Spad pilot added power, climbing into a chandelle.',
+      title: 'On Yankee Station',
+      displayOrder: 0,
+    });
+  });
+
+  it('should fetch the previously inserted word by display date', async () => {
+    const result = await getDailyWordByDisplayDate(displayDate);
+
+    expect(result).toBeDefined();
+    expect(result?.word).toBe('chandelle');
+    expect(result?.definitions).toHaveLength(2);
+    expect(result?.examples).toHaveLength(2);
+  });
+
+  it('should return undefined when no word exists for the display date', async () => {
+    const result = await getDailyWordByDisplayDate(noRowDisplayDate);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should reject inserting a duplicate display date', async () => {
+    await expect(
+      insertDailyWord(fixturePayload, displayDate),
+    ).rejects.toThrow();
+  });
+});

--- a/src/__tests__/daily-word-service.test.ts
+++ b/src/__tests__/daily-word-service.test.ts
@@ -1,0 +1,96 @@
+import dayjs from 'dayjs';
+import { getWordOfTheDayService } from '../server/services/dailyWordService';
+import {
+  getDailyWordByDisplayDate,
+  insertDailyWord,
+} from '../server/utils/db-operation-helpers';
+import { fetchWordOfTheDay } from '../server/utils/wordnikClient';
+import { DailyWord, WordnikWordOfTheDayResponse } from '../server/utils/types';
+
+jest.mock('../server/utils/db-operation-helpers', () => ({
+  getDailyWordByDisplayDate: jest.fn(),
+  insertDailyWord: jest.fn(),
+}));
+
+jest.mock('../server/utils/wordnikClient', () => ({
+  fetchWordOfTheDay: jest.fn(),
+}));
+
+const cachedWord: DailyWord = {
+  id: '1',
+  wordnikId: 'wordnik-1',
+  word: 'chandelle',
+  displayDate: dayjs().format('YYYY-MM-DD'),
+  publishDate: '2026-07-21T03:00:00.000Z',
+  providerName: 'wordnik',
+  providerId: 711,
+  note: null,
+  htmlExtra: null,
+  definitions: [],
+  examples: [],
+};
+
+const wordnikResponse: WordnikWordOfTheDayResponse = {
+  _id: 'wordnik-2',
+  word: 'petrichor',
+  publishDate: '2026-07-22T03:00:00.000Z',
+  contentProvider: { name: 'wordnik', id: 711 },
+  note: null,
+  htmlExtra: null,
+  pdd: dayjs().format('YYYY-MM-DD'),
+  definitions: [],
+  examples: [],
+};
+
+const insertedWord: DailyWord = {
+  ...cachedWord,
+  id: '2',
+  wordnikId: 'wordnik-2',
+  word: 'petrichor',
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getWordOfTheDayService', () => {
+  it('should return the cached word for today without calling Wordnik', async () => {
+    (getDailyWordByDisplayDate as jest.Mock).mockResolvedValue(cachedWord);
+
+    const result = await getWordOfTheDayService();
+
+    expect(result).toEqual(cachedWord);
+    expect(getDailyWordByDisplayDate).toHaveBeenCalledWith(
+      dayjs().format('YYYY-MM-DD'),
+    );
+    expect(fetchWordOfTheDay).not.toHaveBeenCalled();
+    expect(insertDailyWord).not.toHaveBeenCalled();
+  });
+
+  it('should fetch from Wordnik and persist it when nothing is cached for today', async () => {
+    (getDailyWordByDisplayDate as jest.Mock).mockResolvedValue(undefined);
+    (fetchWordOfTheDay as jest.Mock).mockResolvedValue(wordnikResponse);
+    (insertDailyWord as jest.Mock).mockResolvedValue(insertedWord);
+
+    const result = await getWordOfTheDayService();
+
+    expect(fetchWordOfTheDay).toHaveBeenCalledTimes(1);
+    expect(insertDailyWord).toHaveBeenCalledWith(
+      wordnikResponse,
+      dayjs().format('YYYY-MM-DD'),
+    );
+    expect(result).toEqual(insertedWord);
+  });
+
+  it('should propagate an error if the Wordnik fetch fails on a cache miss', async () => {
+    (getDailyWordByDisplayDate as jest.Mock).mockResolvedValue(undefined);
+    (fetchWordOfTheDay as jest.Mock).mockRejectedValue(
+      new Error('Missing required environment variable: WORDNIK_API_KEY'),
+    );
+
+    await expect(getWordOfTheDayService()).rejects.toThrow(
+      'Missing required environment variable: WORDNIK_API_KEY',
+    );
+    expect(insertDailyWord).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import BudgetOutlet from './budgeting-page/shared-budget-components/Outlets';
 
 import './App.css';
 import ExpenseDetailsHomePage from './budgeting-page/budget-components/ExpenseDetailsComponents/ExpenseDetailsHomePage';
+import WordOfTheDay from './WordOfTheDay';
 
 function App() {
   return (
@@ -21,9 +22,7 @@ function App() {
             path="/"
             element={
               <header className="App-header">
-                <p>
-                  Edit <code>src/App.tsx</code> and save to reload.
-                </p>
+                <WordOfTheDay />
                 <Button
                   variant="contained"
                   color="primary"

--- a/src/app/WordOfTheDay.tsx
+++ b/src/app/WordOfTheDay.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import en from './i18n/en';
+
+const WordOfTheDay: React.FC = () => {
+  const [word, setWord] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    const fetchWordOfTheDay = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.REACT_APP_API_URL}/daily-word`,
+        );
+        setWord(response.data.word);
+      } catch (error: unknown) {
+        error instanceof Error
+          ? setError(error.message)
+          : setError(en.errors.unknownError);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchWordOfTheDay();
+  }, []);
+
+  if (loading) {
+    return <p>{en.wordOfTheDay.loading}</p>;
+  }
+
+  if (error) {
+    return <p>Error: {error}</p>;
+  }
+
+  return (
+    <p id="word-of-the-day">
+      {en.wordOfTheDay.prefix} {word}
+    </p>
+  );
+};
+
+export default WordOfTheDay;

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -25,6 +25,10 @@ const en = {
   errors: {
     unknownError: 'An unknown error occurred',
   },
+  wordOfTheDay: {
+    loading: 'Loading word of the day...',
+    prefix: 'word of the day',
+  },
 };
 
 export default en;

--- a/src/server/controllers/dailyWordController.ts
+++ b/src/server/controllers/dailyWordController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { getWordOfTheDayService } from '../services/dailyWordService';
+import logger from '../utils/logger';
+
+export const getWordOfTheDayController = async (
+  _req: Request,
+  res: Response,
+) => {
+  try {
+    const data = await getWordOfTheDayService();
+    res.json(data);
+  } catch (error) {
+    logger.error(`Error fetching word of the day: ${error}`);
+    res.status(500).json({ error: `Internal Server Error ${error}` });
+  }
+};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,6 +4,7 @@ import db from '../config/db';
 import cors from 'cors';
 import logger from './utils/logger';
 import budgetRoutes from './routes/budgetRoutes';
+import dailyWordRoutes from './routes/dailyWordRoutes';
 import compression from 'compression';
 import cluster from 'node:cluster';
 import process from 'node:process';
@@ -44,6 +45,7 @@ if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
 
   // Enable URL-encoded body parsing
   app.use('/budget', budgetRoutes);
+  app.use('/daily-word', dailyWordRoutes);
 
   // Health check for uptime monitoring
   app.get('/health', healthCheckHandler);
@@ -86,6 +88,7 @@ if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
 
   // Enable URL-encoded body parsing
   app.use('/budget', budgetRoutes);
+  app.use('/daily-word', dailyWordRoutes);
 
   // Health check for uptime monitoring
   app.get('/health', healthCheckHandler);

--- a/src/server/routes/dailyWordRoutes.ts
+++ b/src/server/routes/dailyWordRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getWordOfTheDayController } from '../controllers/dailyWordController';
+
+const router = Router();
+
+// GETS
+router.get('/', getWordOfTheDayController);
+
+export default router;

--- a/src/server/services/dailyWordService.ts
+++ b/src/server/services/dailyWordService.ts
@@ -1,0 +1,20 @@
+import dayjs from 'dayjs';
+import { DailyWord } from '../utils/types';
+import {
+  getDailyWordByDisplayDate,
+  insertDailyWord,
+} from '../utils/db-operation-helpers';
+import { fetchWordOfTheDay } from '../utils/wordnikClient';
+
+export const getWordOfTheDayService = async (): Promise<DailyWord> => {
+  const today = dayjs().format('YYYY-MM-DD');
+
+  const existingWord = await getDailyWordByDisplayDate(today);
+  if (existingWord) {
+    return existingWord;
+  }
+
+  const wordnikResponse = await fetchWordOfTheDay();
+
+  return await insertDailyWord(wordnikResponse, today);
+};

--- a/src/server/services/dailyWordService.ts
+++ b/src/server/services/dailyWordService.ts
@@ -16,5 +16,14 @@ export const getWordOfTheDayService = async (): Promise<DailyWord> => {
 
   const wordnikResponse = await fetchWordOfTheDay();
 
-  return await insertDailyWord(wordnikResponse, today);
+  try {
+    return await insertDailyWord(wordnikResponse, today);
+  } catch (error) {
+    // If another request inserted today's word concurrently, read it back instead of failing.
+    const wordAfterInsertRace = await getDailyWordByDisplayDate(today);
+    if (wordAfterInsertRace) {
+      return wordAfterInsertRace;
+    }
+    throw error;
+  }
 };

--- a/src/server/utils/consts.ts
+++ b/src/server/utils/consts.ts
@@ -1,6 +1,8 @@
 // Error messages
 export const ErrorFetchingBudgetData = 'Error fetching budget data';
 export const ErrorInsertingExpense = 'Error inserting expense';
+export const ErrorFetchingDailyWord = 'Error fetching daily word';
+export const ErrorInsertingDailyWord = 'Error inserting daily word';
 
 // PDF generation constants
 export const monthlyBudgetReportCSS = 'monthlyReportStyleSheet.css';

--- a/src/server/utils/db-operation-helpers.ts
+++ b/src/server/utils/db-operation-helpers.ts
@@ -268,7 +268,7 @@ export const insertDailyWord = async (
           provider_id: payload.contentProvider?.id ?? null,
           note: payload.note ?? null,
           html_extra: payload.htmlExtra ?? null,
-          raw_payload: JSON.stringify(payload),
+          raw_payload: payload,
         })
         .returning('*');
 

--- a/src/server/utils/db-operation-helpers.ts
+++ b/src/server/utils/db-operation-helpers.ts
@@ -1,15 +1,23 @@
+import dayjs from 'dayjs';
 import db from '../../config/db';
 import logger from './logger';
 import {
   BudgetType,
   CurrentYearlyAccumulatedData,
+  DailyWord,
   InsertExpenseType,
   InsertResponseId,
   MonthlyExpense,
   MonthlyExpenseWithReimbursable,
   UpdateExpenseType,
+  WordnikWordOfTheDayResponse,
 } from './types';
-import { ErrorFetchingBudgetData, ErrorInsertingExpense } from './consts';
+import {
+  ErrorFetchingBudgetData,
+  ErrorFetchingDailyWord,
+  ErrorInsertingDailyWord,
+  ErrorInsertingExpense,
+} from './consts';
 import { validateReimbursableExpense } from './utils';
 
 export const getAllBudgetData = async (): Promise<BudgetType[]> => {
@@ -212,6 +220,127 @@ export const simpleSelect = async (): Promise<boolean> => {
     throw error;
   }
 };
+
+export const getDailyWordByDisplayDate = async (
+  displayDate: string,
+): Promise<DailyWord | undefined> => {
+  try {
+    const wordRow = await db('daily_words')
+      .select('*')
+      .where('display_date', displayDate)
+      .first();
+
+    if (!wordRow) {
+      return undefined;
+    }
+
+    const [definitionRows, exampleRows] = await Promise.all([
+      db('daily_word_definitions')
+        .select('*')
+        .where('daily_word_id', wordRow.id)
+        .orderBy('display_order', 'asc'),
+      db('daily_word_examples')
+        .select('*')
+        .where('daily_word_id', wordRow.id)
+        .orderBy('display_order', 'asc'),
+    ]);
+
+    return formatDailyWordRow(wordRow, definitionRows, exampleRows);
+  } catch (error) {
+    logger.error(`${ErrorFetchingDailyWord}: ${error}`);
+    throw error;
+  }
+};
+
+export const insertDailyWord = async (
+  payload: WordnikWordOfTheDayResponse,
+  displayDate: string,
+): Promise<DailyWord> => {
+  try {
+    return await db.transaction(async (trx) => {
+      const [wordRow] = await trx('daily_words')
+        .insert({
+          wordnik_id: payload._id,
+          word: payload.word,
+          display_date: displayDate,
+          publish_date: payload.publishDate,
+          provider_name: payload.contentProvider?.name,
+          provider_id: payload.contentProvider?.id ?? null,
+          note: payload.note ?? null,
+          html_extra: payload.htmlExtra ?? null,
+          raw_payload: JSON.stringify(payload),
+        })
+        .returning('*');
+
+      const definitionRows = payload.definitions?.length
+        ? await trx('daily_word_definitions')
+            .insert(
+              payload.definitions.map((definition, index) => ({
+                daily_word_id: wordRow.id,
+                definition: definition.text,
+                part_of_speech: definition.partOfSpeech ?? null,
+                source: definition.source ?? null,
+                note: definition.note ?? null,
+                display_order: index,
+              })),
+            )
+            .returning('*')
+        : [];
+
+      const exampleRows = payload.examples?.length
+        ? await trx('daily_word_examples')
+            .insert(
+              payload.examples.map((example, index) => ({
+                daily_word_id: wordRow.id,
+                wordnik_example_id: example.id ?? null,
+                example_text: example.text,
+                title: example.title ?? null,
+                source_url: example.url ?? null,
+                display_order: index,
+              })),
+            )
+            .returning('*')
+        : [];
+
+      logger.info(`Inserted daily word ${wordRow.word} for ${displayDate}`);
+
+      return formatDailyWordRow(wordRow, definitionRows, exampleRows);
+    });
+  } catch (error) {
+    logger.error(`${ErrorInsertingDailyWord}: ${error}`);
+    throw error;
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const formatDailyWordRow = (
+  wordRow: any,
+  definitionRows: any[],
+  exampleRows: any[],
+): DailyWord => ({
+  id: wordRow.id,
+  wordnikId: wordRow.wordnik_id,
+  word: wordRow.word,
+  displayDate: dayjs(wordRow.display_date).format('YYYY-MM-DD'),
+  publishDate: dayjs(wordRow.publish_date).toISOString(),
+  providerName: wordRow.provider_name,
+  providerId: wordRow.provider_id,
+  note: wordRow.note,
+  htmlExtra: wordRow.html_extra,
+  definitions: definitionRows.map((row) => ({
+    definition: row.definition,
+    partOfSpeech: row.part_of_speech,
+    source: row.source,
+    note: row.note,
+    displayOrder: row.display_order,
+  })),
+  examples: exampleRows.map((row) => ({
+    exampleText: row.example_text,
+    title: row.title,
+    sourceUrl: row.source_url,
+    displayOrder: row.display_order,
+  })),
+});
 
 export const getAccumulatedYearlyData = async (
   month: string,

--- a/src/server/utils/types.ts
+++ b/src/server/utils/types.ts
@@ -121,3 +121,62 @@ export type GenerateReportInput = {
   aggregateYearlyData: CurrentYearlyAccumulatedData[];
   YYYYMM: string;
 };
+
+// Wordnik "word of the day" API response shape
+export type WordnikDefinition = {
+  text: string;
+  partOfSpeech: string | null;
+  source: string | null;
+  note: string | null;
+};
+
+export type WordnikExample = {
+  id?: number;
+  url: string | null;
+  text: string;
+  title: string | null;
+};
+
+export type WordnikWordOfTheDayResponse = {
+  _id: string;
+  word: string;
+  publishDate: string;
+  contentProvider: {
+    name: string;
+    id: number;
+  };
+  note: string | null;
+  htmlExtra: string | null;
+  pdd: string;
+  definitions: WordnikDefinition[];
+  examples: WordnikExample[];
+};
+
+export type DailyWordDefinition = {
+  definition: string;
+  partOfSpeech: string | null;
+  source: string | null;
+  note: string | null;
+  displayOrder: number;
+};
+
+export type DailyWordExample = {
+  exampleText: string;
+  title: string | null;
+  sourceUrl: string | null;
+  displayOrder: number;
+};
+
+export type DailyWord = {
+  id: string;
+  wordnikId: string;
+  word: string;
+  displayDate: string;
+  publishDate: string;
+  providerName: string;
+  providerId: number | null;
+  note: string | null;
+  htmlExtra: string | null;
+  definitions: DailyWordDefinition[];
+  examples: DailyWordExample[];
+};

--- a/src/server/utils/wordnikClient.ts
+++ b/src/server/utils/wordnikClient.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import logger from './logger';
+import { WordnikWordOfTheDayResponse } from './types';
+
+const WORDNIK_WORD_OF_THE_DAY_URL =
+  'https://api.wordnik.com/v4/words.json/wordOfTheDay';
+
+export const fetchWordOfTheDay =
+  async (): Promise<WordnikWordOfTheDayResponse> => {
+    const apiKey = process.env.WORDNIK_API_KEY;
+
+    if (!apiKey) {
+      throw new Error('Missing required environment variable: WORDNIK_API_KEY');
+    }
+
+    try {
+      const response = await axios.get<WordnikWordOfTheDayResponse>(
+        WORDNIK_WORD_OF_THE_DAY_URL,
+        { params: { api_key: apiKey } },
+      );
+
+      return response.data;
+    } catch (error) {
+      logger.error(`Error fetching word of the day from Wordnik: ${error}`);
+      throw error;
+    }
+  };


### PR DESCRIPTION

What

Adds a "Word of the Day" feature to the home page, backed by the Wordnik API and cached daily in Postgres.

Why

The home page currently just shows placeholder boilerplate text (Edit src/App.tsx and save to reload.). This replaces it with a small, self-contained feature to make the landing page useful, and lays down the DB/service/controller pattern for future Home-pillar features.

Changes

- Frontend: new WordOfTheDay component (src/app/WordOfTheDay.tsx) fetches /daily-word on mount and renders it on the home page (App.tsx); loading/prefix copy added to src/app/i18n/en.ts
- Backend: new /daily-word route → dailyWordController → dailyWordService → db-operation-helpers, following the existing layer pattern; mounted in src/server/index.ts
  - dailyWordService.getWordOfTheDayService checks Postgres for today's cached word first, and only calls Wordnik on a cache miss
  - wordnikClient.fetchWordOfTheDay calls the Wordnik wordOfTheDay API, gated on a WORDNIK_API_KEY env var
- Database: new migration creates daily_words, daily_word_definitions, and daily_word_examples tables (definitions/examples cascade-delete with their parent word; one row per calendar day via a unique constraint on display_date)
- Types: added WordnikWordOfTheDayResponse/WordnikDefinition/WordnikExample (external API shape) and DailyWord/DailyWordDefinition/DailyWordExample (internal shape) to src/server/utils/types.ts
- Tests: unit tests for the controller, service, and DB operations (src/__tests__/daily-word-*.test.ts); Cypress end-to-end test verifying the word renders and is re-served from cache on reload