### PR TITLE
Wordnik API timezone patch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,8 @@ Layer pattern: `routes/ → controllers/ → services/ → db-operation-helpers.
 
 In dev/test `NODE_ENV`, clustering is disabled (single process). In production, the server forks workers based on `HEROKU_AVAILABLE_PARALLELISM` / `WEB_CONCURRENCY` — `HEROKU_AVAILABLE_PARALLELISM` is a legacy fallback from a prior Heroku deployment; Railway doesn't set it, so this falls through to `WEB_CONCURRENCY` (or a single worker if neither is set).
 
+`dailyWordService.ts` keys `display_date` off Wordnik's own `pdd` field rather than server-local time, since Wordnik's day rollover (US Eastern) doesn't line up with the server's UTC clock.
+
 ### Database (`src/config/db.ts`, `db/migrations/`)
 
 Knex connects to Postgres. Dev DB: `postgres://postgres:@localhost:5432/dash-test`. Config auto-selects `.env.development` or `.env.production` based on `NODE_ENV`.

--- a/src/__tests__/daily-word-service.test.ts
+++ b/src/__tests__/daily-word-service.test.ts
@@ -2,13 +2,16 @@ import dayjs from 'dayjs';
 import { getWordOfTheDayService } from '../server/services/dailyWordService';
 import {
   getDailyWordByDisplayDate,
+  getDailyWordByWordnikId,
   insertDailyWord,
 } from '../server/utils/db-operation-helpers';
 import { fetchWordOfTheDay } from '../server/utils/wordnikClient';
 import { DailyWord, WordnikWordOfTheDayResponse } from '../server/utils/types';
+import logger from '../server/utils/logger';
 
 jest.mock('../server/utils/db-operation-helpers', () => ({
   getDailyWordByDisplayDate: jest.fn(),
+  getDailyWordByWordnikId: jest.fn(),
   insertDailyWord: jest.fn(),
 }));
 
@@ -16,11 +19,14 @@ jest.mock('../server/utils/wordnikClient', () => ({
   fetchWordOfTheDay: jest.fn(),
 }));
 
+const today = dayjs().format('YYYY-MM-DD');
+const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
+
 const cachedWord: DailyWord = {
   id: '1',
   wordnikId: 'wordnik-1',
   word: 'chandelle',
-  displayDate: dayjs().format('YYYY-MM-DD'),
+  displayDate: today,
   publishDate: '2026-07-21T03:00:00.000Z',
   providerName: 'wordnik',
   providerId: 711,
@@ -37,7 +43,7 @@ const wordnikResponse: WordnikWordOfTheDayResponse = {
   contentProvider: { name: 'wordnik', id: 711 },
   note: null,
   htmlExtra: null,
-  pdd: dayjs().format('YYYY-MM-DD'),
+  pdd: today,
   definitions: [],
   examples: [],
 };
@@ -49,8 +55,22 @@ const insertedWord: DailyWord = {
   word: 'petrichor',
 };
 
+let loggerInfoSpy: jest.SpyInstance;
+let loggerErrorSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerInfoSpy = jest
+    .spyOn(logger, 'info')
+    .mockImplementation(jest.fn() as never);
+  loggerErrorSpy = jest
+    .spyOn(logger, 'error')
+    .mockImplementation(jest.fn() as never);
+});
+
 afterEach(() => {
   jest.clearAllMocks();
+  loggerInfoSpy.mockRestore();
+  loggerErrorSpy.mockRestore();
 });
 
 describe('getWordOfTheDayService', () => {
@@ -60,14 +80,12 @@ describe('getWordOfTheDayService', () => {
     const result = await getWordOfTheDayService();
 
     expect(result).toEqual(cachedWord);
-    expect(getDailyWordByDisplayDate).toHaveBeenCalledWith(
-      dayjs().format('YYYY-MM-DD'),
-    );
+    expect(getDailyWordByDisplayDate).toHaveBeenCalledWith(today);
     expect(fetchWordOfTheDay).not.toHaveBeenCalled();
     expect(insertDailyWord).not.toHaveBeenCalled();
   });
 
-  it('should fetch from Wordnik and persist it when nothing is cached for today', async () => {
+  it("should fetch from Wordnik and persist it under Wordnik's pdd when nothing is cached for today", async () => {
     (getDailyWordByDisplayDate as jest.Mock).mockResolvedValue(undefined);
     (fetchWordOfTheDay as jest.Mock).mockResolvedValue(wordnikResponse);
     (insertDailyWord as jest.Mock).mockResolvedValue(insertedWord);
@@ -77,7 +95,7 @@ describe('getWordOfTheDayService', () => {
     expect(fetchWordOfTheDay).toHaveBeenCalledTimes(1);
     expect(insertDailyWord).toHaveBeenCalledWith(
       wordnikResponse,
-      dayjs().format('YYYY-MM-DD'),
+      wordnikResponse.pdd,
     );
     expect(result).toEqual(insertedWord);
   });
@@ -94,10 +112,38 @@ describe('getWordOfTheDayService', () => {
     expect(insertDailyWord).not.toHaveBeenCalled();
   });
 
-  it('should read back the winning word if another request inserted it first', async () => {
+  it("should reconcile against Wordnik's pdd when it lags the server's local date and return the word already stored under that date", async () => {
+    const laggedResponse = { ...wordnikResponse, pdd: yesterday };
     (getDailyWordByDisplayDate as jest.Mock)
-      .mockResolvedValueOnce(undefined) // initial cache check: nothing yet
-      .mockResolvedValueOnce(cachedWord); // re-read after the insert race
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ ...cachedWord, displayDate: yesterday });
+
+    (fetchWordOfTheDay as jest.Mock).mockResolvedValue(laggedResponse);
+
+    const result = await getWordOfTheDayService();
+
+    expect(getDailyWordByDisplayDate).toHaveBeenNthCalledWith(1, today);
+    expect(getDailyWordByDisplayDate).toHaveBeenNthCalledWith(2, yesterday);
+    expect(insertDailyWord).not.toHaveBeenCalled();
+    expect(result).toEqual({ ...cachedWord, displayDate: yesterday });
+  });
+
+  it("should insert under Wordnik's pdd, not local today, when nothing exists yet for either date", async () => {
+    const laggedResponse = { ...wordnikResponse, pdd: yesterday };
+    (getDailyWordByDisplayDate as jest.Mock).mockResolvedValue(undefined);
+    (fetchWordOfTheDay as jest.Mock).mockResolvedValue(laggedResponse);
+    (insertDailyWord as jest.Mock).mockResolvedValue(insertedWord);
+
+    const result = await getWordOfTheDayService();
+
+    expect(insertDailyWord).toHaveBeenCalledWith(laggedResponse, yesterday);
+    expect(result).toEqual(insertedWord);
+  });
+
+  it('should read back the winning word if another request inserted it first (benign concurrent race)', async () => {
+    (getDailyWordByDisplayDate as jest.Mock)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(cachedWord);
     (fetchWordOfTheDay as jest.Mock).mockResolvedValue(wordnikResponse);
     (insertDailyWord as jest.Mock).mockRejectedValue(
       new Error('duplicate key value violates unique constraint'),
@@ -107,9 +153,40 @@ describe('getWordOfTheDayService', () => {
 
     expect(getDailyWordByDisplayDate).toHaveBeenCalledTimes(2);
     expect(result).toEqual(cachedWord);
+    expect(getDailyWordByWordnikId).not.toHaveBeenCalled();
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('inserted by a concurrent request'),
+    );
+    expect(loggerErrorSpy).not.toHaveBeenCalled();
   });
 
-  it('should propagate the insert error if the retry read-back also finds nothing', async () => {
+  it('should log an unexpected-duplicate error and rethrow when the wordnik_id already exists under a different display_date', async () => {
+    (getDailyWordByDisplayDate as jest.Mock)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    (fetchWordOfTheDay as jest.Mock).mockResolvedValue(wordnikResponse);
+    (insertDailyWord as jest.Mock).mockRejectedValue(
+      new Error(
+        'duplicate key value violates unique constraint "daily_words_wordnik_id_unique"',
+      ),
+    );
+    (getDailyWordByWordnikId as jest.Mock).mockResolvedValue({
+      ...cachedWord,
+      wordnikId: wordnikResponse._id,
+      displayDate: yesterday,
+    });
+
+    await expect(getWordOfTheDayService()).rejects.toThrow(
+      'duplicate key value violates unique constraint',
+    );
+
+    expect(getDailyWordByWordnikId).toHaveBeenCalledWith(wordnikResponse._id);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unexpected daily word duplicate'),
+    );
+  });
+
+  it('should propagate the insert error if both the retry read-back and the wordnik_id lookup find nothing', async () => {
     (getDailyWordByDisplayDate as jest.Mock)
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined);
@@ -117,10 +194,12 @@ describe('getWordOfTheDayService', () => {
     (insertDailyWord as jest.Mock).mockRejectedValue(
       new Error('connection terminated'),
     );
+    (getDailyWordByWordnikId as jest.Mock).mockResolvedValue(undefined);
 
     await expect(getWordOfTheDayService()).rejects.toThrow(
       'connection terminated',
     );
     expect(getDailyWordByDisplayDate).toHaveBeenCalledTimes(2);
+    expect(getDailyWordByWordnikId).toHaveBeenCalledWith(wordnikResponse._id);
   });
 });

--- a/src/server/services/dailyWordService.ts
+++ b/src/server/services/dailyWordService.ts
@@ -2,9 +2,12 @@ import dayjs from 'dayjs';
 import { DailyWord } from '../utils/types';
 import {
   getDailyWordByDisplayDate,
+  getDailyWordByWordnikId,
   insertDailyWord,
 } from '../utils/db-operation-helpers';
 import { fetchWordOfTheDay } from '../utils/wordnikClient';
+import { ErrorUnexpectedDailyWordDuplicate } from '../utils/consts';
+import logger from '../utils/logger';
 
 export const getWordOfTheDayService = async (): Promise<DailyWord> => {
   const today = dayjs().format('YYYY-MM-DD');
@@ -15,15 +18,32 @@ export const getWordOfTheDayService = async (): Promise<DailyWord> => {
   }
 
   const wordnikResponse = await fetchWordOfTheDay();
+  const displayDate = wordnikResponse.pdd;
+
+  if (displayDate !== today) {
+    const existingForDisplayDate = await getDailyWordByDisplayDate(displayDate);
+    if (existingForDisplayDate) {
+      return existingForDisplayDate;
+    }
+  }
 
   try {
-    return await insertDailyWord(wordnikResponse, today);
+    return await insertDailyWord(wordnikResponse, displayDate);
   } catch (error) {
-    // If another request inserted today's word concurrently, read it back instead of failing.
-    const wordAfterInsertRace = await getDailyWordByDisplayDate(today);
+    const wordAfterInsertRace = await getDailyWordByDisplayDate(displayDate);
     if (wordAfterInsertRace) {
+      logger.info(
+        `Daily word for ${displayDate} was inserted by a concurrent request; returning it instead of failing.`,
+      );
       return wordAfterInsertRace;
     }
+
+    const existingByWordnikId = await getDailyWordByWordnikId(
+      wordnikResponse._id,
+    );
+    logger.error(
+      `${ErrorUnexpectedDailyWordDuplicate}: wordnik_id=${wordnikResponse._id} attemptedDisplayDate=${displayDate} existingDisplayDate=${existingByWordnikId?.displayDate ?? 'unknown'}: ${error}`,
+    );
     throw error;
   }
 };

--- a/src/server/utils/consts.ts
+++ b/src/server/utils/consts.ts
@@ -3,6 +3,8 @@ export const ErrorFetchingBudgetData = 'Error fetching budget data';
 export const ErrorInsertingExpense = 'Error inserting expense';
 export const ErrorFetchingDailyWord = 'Error fetching daily word';
 export const ErrorInsertingDailyWord = 'Error inserting daily word';
+export const ErrorUnexpectedDailyWordDuplicate =
+  'Unexpected daily word duplicate: wordnik_id already stored under a different display_date';
 
 // PDF generation constants
 export const monthlyBudgetReportCSS = 'monthlyReportStyleSheet.css';

--- a/src/server/utils/db-operation-helpers.ts
+++ b/src/server/utils/db-operation-helpers.ts
@@ -252,6 +252,37 @@ export const getDailyWordByDisplayDate = async (
   }
 };
 
+export const getDailyWordByWordnikId = async (
+  wordnikId: string,
+): Promise<DailyWord | undefined> => {
+  try {
+    const wordRow = await db('daily_words')
+      .select('*')
+      .where('wordnik_id', wordnikId)
+      .first();
+
+    if (!wordRow) {
+      return undefined;
+    }
+
+    const [definitionRows, exampleRows] = await Promise.all([
+      db('daily_word_definitions')
+        .select('*')
+        .where('daily_word_id', wordRow.id)
+        .orderBy('display_order', 'asc'),
+      db('daily_word_examples')
+        .select('*')
+        .where('daily_word_id', wordRow.id)
+        .orderBy('display_order', 'asc'),
+    ]);
+
+    return formatDailyWordRow(wordRow, definitionRows, exampleRows);
+  } catch (error) {
+    logger.error(`${ErrorFetchingDailyWord}: ${error}`);
+    throw error;
+  }
+};
+
 export const insertDailyWord = async (
   payload: WordnikWordOfTheDayResponse,
   displayDate: string,


### PR DESCRIPTION
### What

Fixes Word of the Day caching to key off Wordnik's own pdd date instead of the server's local date, so entries aren't duplicated or missed around Wordnik's US Eastern day rollover.

### Why

Wordnik's daily word rolls over at US Eastern midnight, which doesn't line up with the servalways cached/inserted using the server's local today, so near the rollover boundary theservice could insert a word under the wrong display_date or fail to find an already-cached word for Wordnik's actual current day.

### Changes

- dailyWordService.ts: use wordnikResponse.pdd as the displayDate for lookups and inserts instead of the server's local date; when pdd differs from local today, check for an existing row under pdd before inserting
- Added getDailyWordByWordnikId (db-operation-helpers.ts) to distinguish a benign concurrent-insert race (same date, already cached) from an unexpected duplicate (same wordnik_id stored under a different display_date), logging each case differently via the new ErrorUnexpectedDailyWordDuplicate constant (consts.ts)
- daily-word-service.test.ts: updated/added tests covering pdd-lagging-local-date reconcilithe two duplicate-key scenarios (concurrent race vs. unexpected duplicate)
- CLAUDE.md: documented the pdd-based display_date behavior in dailyWordService.ts