### PR TITLE
Feature - todo setting up backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-router": "^6.22.0",
     "react-router-dom": "^7.1.3",
     "react-scripts": "^5.0.1",
+    "rrule": "^2.8.1",
     "tachyons": "^4.12.0",
     "typescript": "^4.5.4",
     "web-vitals": "^2.1.4",

--- a/src/__tests__/rrule-helper.test.ts
+++ b/src/__tests__/rrule-helper.test.ts
@@ -1,0 +1,155 @@
+import { validateRRule, expandRRule } from '../server/utils/rruleHelper';
+
+describe('validateRRule', () => {
+  it('should accept FREQ=DAILY', () => {
+    expect(() => validateRRule('FREQ=DAILY')).not.toThrow();
+  });
+
+  it('should accept FREQ=WEEKLY', () => {
+    expect(() => validateRRule('FREQ=WEEKLY;BYDAY=MO')).not.toThrow();
+  });
+
+  it('should accept FREQ=MONTHLY', () => {
+    expect(() => validateRRule('FREQ=MONTHLY;BYMONTHDAY=15')).not.toThrow();
+  });
+
+  it('should accept FREQ=YEARLY', () => {
+    expect(() => validateRRule('FREQ=YEARLY')).not.toThrow();
+  });
+
+  it('should reject invalid RRULE strings', () => {
+    expect(() => validateRRule('NOT_A_RULE')).toThrow(
+      'Invalid recurrence rule',
+    );
+  });
+
+  it('should reject FREQ=HOURLY', () => {
+    expect(() => validateRRule('FREQ=HOURLY')).toThrow('Unsupported frequency');
+  });
+
+  it('should reject FREQ=MINUTELY', () => {
+    expect(() => validateRRule('FREQ=MINUTELY')).toThrow(
+      'Unsupported frequency',
+    );
+  });
+
+  it('should reject FREQ=SECONDLY', () => {
+    expect(() => validateRRule('FREQ=SECONDLY')).toThrow(
+      'Unsupported frequency',
+    );
+  });
+});
+
+describe('expandRRule', () => {
+  it('should expand FREQ=DAILY', () => {
+    const dates = expandRRule(
+      'FREQ=DAILY',
+      '2026-08-01',
+      '2026-08-01',
+      '2026-08-05',
+    );
+    expect(dates).toEqual([
+      '2026-08-02',
+      '2026-08-03',
+      '2026-08-04',
+      '2026-08-05',
+    ]);
+  });
+
+  it('should expand FREQ=WEEKLY;BYDAY=MO,WE,FR', () => {
+    const dates = expandRRule(
+      'FREQ=WEEKLY;BYDAY=MO,WE,FR',
+      '2026-08-03',
+      '2026-08-03',
+      '2026-08-14',
+    );
+    // Aug 3 is a Monday (dtstart), after=Aug 3 (exclusive)
+    // Next: Wed Aug 5, Fri Aug 7, Mon Aug 10, Wed Aug 12, Fri Aug 14
+    expect(dates).toEqual([
+      '2026-08-05',
+      '2026-08-07',
+      '2026-08-10',
+      '2026-08-12',
+      '2026-08-14',
+    ]);
+  });
+
+  it('should expand FREQ=MONTHLY;BYMONTHDAY=15', () => {
+    const dates = expandRRule(
+      'FREQ=MONTHLY;BYMONTHDAY=15',
+      '2026-08-15',
+      '2026-08-15',
+      '2026-11-15',
+    );
+    expect(dates).toEqual(['2026-09-15', '2026-10-15', '2026-11-15']);
+  });
+
+  it('should expand FREQ=YEARLY', () => {
+    const dates = expandRRule(
+      'FREQ=YEARLY',
+      '2026-01-01',
+      '2026-01-01',
+      '2029-01-01',
+    );
+    expect(dates).toEqual(['2027-01-01', '2028-01-01', '2029-01-01']);
+  });
+
+  it('should respect endsOn boundary', () => {
+    const dates = expandRRule(
+      'FREQ=DAILY',
+      '2026-08-01',
+      '2026-08-01',
+      '2026-08-10',
+      '2026-08-05',
+    );
+    expect(dates).toEqual([
+      '2026-08-02',
+      '2026-08-03',
+      '2026-08-04',
+      '2026-08-05',
+    ]);
+  });
+
+  it('should return empty array when no occurrences in range', () => {
+    const dates = expandRRule(
+      'FREQ=WEEKLY;BYDAY=SA',
+      '2026-08-03',
+      '2026-08-03',
+      '2026-08-07',
+    );
+    // Aug 3 is Monday, no Saturday before Aug 7
+    expect(dates).toEqual([]);
+  });
+
+  it('should exclude the after date (exclusive lower bound)', () => {
+    const dates = expandRRule(
+      'FREQ=DAILY',
+      '2026-08-01',
+      '2026-08-01',
+      '2026-08-03',
+    );
+    expect(dates[0]).toBe('2026-08-02');
+    expect(dates).not.toContain('2026-08-01');
+  });
+
+  it('should include the before date (inclusive upper bound)', () => {
+    const dates = expandRRule(
+      'FREQ=DAILY',
+      '2026-08-01',
+      '2026-08-01',
+      '2026-08-03',
+    );
+    expect(dates).toContain('2026-08-03');
+  });
+
+  it('should handle generatedThrough as after date', () => {
+    // Simulates incremental materialization: already generated through Aug 5
+    const dates = expandRRule(
+      'FREQ=DAILY',
+      '2026-08-01',
+      '2026-08-05',
+      '2026-08-08',
+    );
+    expect(dates).toEqual(['2026-08-06', '2026-08-07', '2026-08-08']);
+  });
+});

--- a/src/__tests__/series-controller.test.ts
+++ b/src/__tests__/series-controller.test.ts
@@ -1,0 +1,273 @@
+import request from 'supertest';
+import { app, server, db } from '../server';
+import {
+  listSeriesService,
+  getSeriesByIdService,
+  createSeriesService,
+  updateSeriesService,
+  pauseSeriesService,
+  resumeSeriesService,
+  archiveSeriesService,
+  validateCreateSeries,
+  validateUpdateSeries,
+} from '../server/services/seriesService';
+import {
+  createTestTaskSeries,
+  createTestCreateSeriesRequest,
+  createTestRecurringTask,
+} from '../server/utils/data-factory/taskTestDataFactory';
+
+jest.mock('../server/services/seriesService', () => ({
+  validateCreateSeries: jest.fn(),
+  validateUpdateSeries: jest.fn(),
+  listSeriesService: jest.fn(),
+  getSeriesByIdService: jest.fn(),
+  createSeriesService: jest.fn(),
+  updateSeriesService: jest.fn(),
+  pauseSeriesService: jest.fn(),
+  resumeSeriesService: jest.fn(),
+  archiveSeriesService: jest.fn(),
+  ensureOccurrencesForDateRange: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../server/services/taskService', () => ({
+  validateCreateTask: jest.fn(),
+  validateUpdateTask: jest.fn(),
+  validateCreateCategory: jest.fn(),
+  validateUpdateCategory: jest.fn(),
+  listCategoriesService: jest.fn(),
+  createCategoryService: jest.fn(),
+  updateCategoryService: jest.fn(),
+  getTaskByIdService: jest.fn(),
+  listTasksService: jest.fn(),
+  createTaskService: jest.fn(),
+  updateTaskService: jest.fn(),
+  deleteTaskService: jest.fn(),
+}));
+
+afterAll(async () => {
+  await db.destroy();
+  server.close();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+// --- GET /tasks/series ---
+
+describe('GET /tasks/series', () => {
+  it('should return a list of series', async () => {
+    const series = [createTestTaskSeries()];
+    (listSeriesService as jest.Mock).mockResolvedValue(series);
+
+    const response = await request(app).get('/tasks/series');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(series);
+  });
+
+  it('should return 500 on service error', async () => {
+    (listSeriesService as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const response = await request(app).get('/tasks/series');
+    expect(response.status).toBe(500);
+  });
+});
+
+// --- POST /tasks/series ---
+
+describe('POST /tasks/series', () => {
+  it('should create a series and return 201', async () => {
+    const validated = createTestCreateSeriesRequest();
+    const series = createTestTaskSeries();
+    const tasks = [createTestRecurringTask()];
+
+    (validateCreateSeries as jest.Mock).mockReturnValue(validated);
+    (createSeriesService as jest.Mock).mockResolvedValue({ series, tasks });
+
+    const response = await request(app).post('/tasks/series').send(validated);
+
+    expect(response.status).toBe(201);
+    expect(response.body.series).toEqual(series);
+    expect(response.body.tasks).toEqual(tasks);
+  });
+
+  it('should return 400 on validation error', async () => {
+    (validateCreateSeries as jest.Mock).mockImplementation(() => {
+      throw new Error('title is required');
+    });
+
+    const response = await request(app).post('/tasks/series').send({});
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('title is required');
+  });
+});
+
+// --- GET /tasks/series/:id ---
+
+describe('GET /tasks/series/:id', () => {
+  it('should return a series by id', async () => {
+    const series = createTestTaskSeries();
+    (getSeriesByIdService as jest.Mock).mockResolvedValue(series);
+
+    const response = await request(app).get('/tasks/series/series-1');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(series);
+  });
+
+  it('should return 404 if not found', async () => {
+    (getSeriesByIdService as jest.Mock).mockResolvedValue(undefined);
+
+    const response = await request(app).get('/tasks/series/missing');
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 500 on service error', async () => {
+    (getSeriesByIdService as jest.Mock).mockRejectedValue(
+      new Error('DB error'),
+    );
+
+    const response = await request(app).get('/tasks/series/series-1');
+    expect(response.status).toBe(500);
+  });
+});
+
+// --- PATCH /tasks/series/:id ---
+
+describe('PATCH /tasks/series/:id', () => {
+  it('should update a series', async () => {
+    const series = createTestTaskSeries({ title: 'Updated' });
+    (validateUpdateSeries as jest.Mock).mockReturnValue({ title: 'Updated' });
+    (updateSeriesService as jest.Mock).mockResolvedValue(series);
+
+    const response = await request(app)
+      .patch('/tasks/series/series-1')
+      .send({ title: 'Updated' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.title).toBe('Updated');
+  });
+
+  it('should return 404 if series not found', async () => {
+    (validateUpdateSeries as jest.Mock).mockReturnValue({ title: 'Nope' });
+    (updateSeriesService as jest.Mock).mockRejectedValue(
+      new Error('Series not found'),
+    );
+
+    const response = await request(app)
+      .patch('/tasks/series/missing')
+      .send({ title: 'Nope' });
+
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 400 on validation error', async () => {
+    (validateUpdateSeries as jest.Mock).mockImplementation(() => {
+      throw new Error('status cannot be changed via update');
+    });
+
+    const response = await request(app)
+      .patch('/tasks/series/series-1')
+      .send({ status: 'paused' });
+
+    expect(response.status).toBe(400);
+  });
+});
+
+// --- POST /tasks/series/:id/pause ---
+
+describe('POST /tasks/series/:id/pause', () => {
+  it('should pause a series', async () => {
+    const paused = createTestTaskSeries({ status: 'paused' });
+    (pauseSeriesService as jest.Mock).mockResolvedValue(paused);
+
+    const response = await request(app).post('/tasks/series/series-1/pause');
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('paused');
+  });
+
+  it('should return 404 if series not found', async () => {
+    (pauseSeriesService as jest.Mock).mockRejectedValue(
+      new Error('Series not found'),
+    );
+
+    const response = await request(app).post('/tasks/series/missing/pause');
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 400 on invalid transition', async () => {
+    (pauseSeriesService as jest.Mock).mockRejectedValue(
+      new Error('Cannot transition from archived to paused'),
+    );
+
+    const response = await request(app).post('/tasks/series/series-1/pause');
+    expect(response.status).toBe(400);
+  });
+});
+
+// --- POST /tasks/series/:id/resume ---
+
+describe('POST /tasks/series/:id/resume', () => {
+  it('should resume a series', async () => {
+    const active = createTestTaskSeries({ status: 'active' });
+    const tasks = [createTestRecurringTask()];
+    (resumeSeriesService as jest.Mock).mockResolvedValue({
+      series: active,
+      tasks,
+    });
+
+    const response = await request(app).post('/tasks/series/series-1/resume');
+    expect(response.status).toBe(200);
+    expect(response.body.series.status).toBe('active');
+    expect(response.body.tasks).toHaveLength(1);
+  });
+
+  it('should return 404 if series not found', async () => {
+    (resumeSeriesService as jest.Mock).mockRejectedValue(
+      new Error('Series not found'),
+    );
+
+    const response = await request(app).post('/tasks/series/missing/resume');
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 400 on invalid transition', async () => {
+    (resumeSeriesService as jest.Mock).mockRejectedValue(
+      new Error('Cannot transition from active to active'),
+    );
+
+    const response = await request(app).post('/tasks/series/series-1/resume');
+    expect(response.status).toBe(400);
+  });
+});
+
+// --- POST /tasks/series/:id/archive ---
+
+describe('POST /tasks/series/:id/archive', () => {
+  it('should archive a series', async () => {
+    const archived = createTestTaskSeries({ status: 'archived' });
+    (archiveSeriesService as jest.Mock).mockResolvedValue(archived);
+
+    const response = await request(app).post('/tasks/series/series-1/archive');
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('archived');
+  });
+
+  it('should return 404 if series not found', async () => {
+    (archiveSeriesService as jest.Mock).mockRejectedValue(
+      new Error('Series not found'),
+    );
+
+    const response = await request(app).post('/tasks/series/missing/archive');
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 400 on invalid transition', async () => {
+    (archiveSeriesService as jest.Mock).mockRejectedValue(
+      new Error('Cannot transition from archived to archived'),
+    );
+
+    const response = await request(app).post('/tasks/series/series-1/archive');
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/__tests__/series-service.test.ts
+++ b/src/__tests__/series-service.test.ts
@@ -1,0 +1,728 @@
+import {
+  validateCreateSeries,
+  validateUpdateSeries,
+  createSeriesService,
+  updateSeriesService,
+  pauseSeriesService,
+  resumeSeriesService,
+  archiveSeriesService,
+  listSeriesService,
+  getSeriesByIdService,
+  ensureTaskOccurrences,
+  ensureOccurrencesForDateRange,
+} from '../server/services/seriesService';
+import {
+  getTaskCategoryById,
+  getTaskSeriesById,
+  getAllActiveTaskSeries,
+  getSeriesNeedingMaterialization,
+  insertTaskSeries,
+  updateTaskSeriesById,
+  getCanceledExceptionDates,
+  materializeOccurrences,
+} from '../server/utils/db-operation-helpers';
+import { validateRRule, expandRRule } from '../server/utils/rruleHelper';
+import {
+  createTestTaskCategory,
+  createTestTaskSeries,
+  createTestCreateSeriesRequest,
+  createTestRecurringTask,
+} from '../server/utils/data-factory/taskTestDataFactory';
+
+jest.mock('../server/utils/db-operation-helpers', () => ({
+  getTaskCategoryById: jest.fn(),
+  getTaskSeriesById: jest.fn(),
+  getAllActiveTaskSeries: jest.fn(),
+  getSeriesNeedingMaterialization: jest.fn(),
+  insertTaskSeries: jest.fn(),
+  updateTaskSeriesById: jest.fn(),
+  getCanceledExceptionDates: jest.fn(),
+  materializeOccurrences: jest.fn(),
+}));
+
+jest.mock('../server/utils/rruleHelper', () => ({
+  validateRRule: jest.fn(),
+  expandRRule: jest.fn(),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+// --- validateCreateSeries ---
+
+describe('validateCreateSeries', () => {
+  it('should return a validated request for valid input', () => {
+    const input = createTestCreateSeriesRequest();
+    const result = validateCreateSeries(input);
+
+    expect(result.title).toBe('Weekly Standup');
+    expect(result.assignedTo).toBe('Yogi');
+    expect(result.kind).toBe('event');
+    expect(result.modality).toBe('virtual');
+    expect(result.timeMode).toBe('timed');
+    expect(result.startsOn).toBe('2026-08-01');
+    expect(result.recurrenceRule).toBe('FREQ=WEEKLY;BYDAY=MO');
+  });
+
+  it('should reject missing title', () => {
+    const input = createTestCreateSeriesRequest({ title: '' });
+    expect(() => validateCreateSeries(input)).toThrow('title is required');
+  });
+
+  it('should reject invalid assignedTo', () => {
+    const input = { ...createTestCreateSeriesRequest(), assignedTo: 'Nobody' };
+    expect(() => validateCreateSeries(input)).toThrow(
+      'assignedTo must be one of',
+    );
+  });
+
+  it('should reject missing categoryId', () => {
+    const input = { ...createTestCreateSeriesRequest(), categoryId: '' };
+    expect(() => validateCreateSeries(input)).toThrow('categoryId is required');
+  });
+
+  it('should reject invalid kind', () => {
+    const input = { ...createTestCreateSeriesRequest(), kind: 'reminder' };
+    expect(() => validateCreateSeries(input)).toThrow('kind must be one of');
+  });
+
+  it('should reject invalid modality', () => {
+    const input = { ...createTestCreateSeriesRequest(), modality: 'hybrid' };
+    expect(() => validateCreateSeries(input)).toThrow(
+      'modality must be one of',
+    );
+  });
+
+  it('should reject invalid timeMode', () => {
+    const input = {
+      ...createTestCreateSeriesRequest(),
+      timeMode: 'flexible',
+    };
+    expect(() => validateCreateSeries(input)).toThrow(
+      'timeMode must be one of',
+    );
+  });
+
+  it('should reject timed mode without startTime', () => {
+    const input = createTestCreateSeriesRequest({
+      timeMode: 'timed',
+      startTime: undefined,
+    });
+    expect(() => validateCreateSeries(input)).toThrow(
+      'startTime is required when timeMode is timed',
+    );
+  });
+
+  it('should reject missing startsOn', () => {
+    const input = { ...createTestCreateSeriesRequest(), startsOn: '' };
+    expect(() => validateCreateSeries(input)).toThrow('startsOn is required');
+  });
+
+  it('should reject missing recurrenceRule', () => {
+    const input = { ...createTestCreateSeriesRequest(), recurrenceRule: '' };
+    expect(() => validateCreateSeries(input)).toThrow(
+      'recurrenceRule is required',
+    );
+  });
+
+  it('should call validateRRule on the recurrence rule', () => {
+    const input = createTestCreateSeriesRequest();
+    validateCreateSeries(input);
+    expect(validateRRule).toHaveBeenCalledWith('FREQ=WEEKLY;BYDAY=MO');
+  });
+
+  it('should reject endsOn before startsOn', () => {
+    const input = {
+      ...createTestCreateSeriesRequest(),
+      endsOn: '2026-07-01',
+    };
+    expect(() => validateCreateSeries(input)).toThrow(
+      'endsOn must be on or after startsOn',
+    );
+  });
+
+  it('should reject non-object metadata', () => {
+    const input = { ...createTestCreateSeriesRequest(), metadata: 'string' };
+    expect(() => validateCreateSeries(input)).toThrow(
+      'metadata must be a plain object',
+    );
+  });
+
+  it('should accept valid endsOn', () => {
+    const input = {
+      ...createTestCreateSeriesRequest(),
+      endsOn: '2026-12-31',
+    };
+    const result = validateCreateSeries(input);
+    expect(result.endsOn).toBe('2026-12-31');
+  });
+});
+
+// --- validateUpdateSeries ---
+
+describe('validateUpdateSeries', () => {
+  it('should accept a partial update', () => {
+    const result = validateUpdateSeries({ title: 'Updated' });
+    expect(result.title).toBe('Updated');
+  });
+
+  it('should reject status field', () => {
+    expect(() => validateUpdateSeries({ status: 'paused' })).toThrow(
+      'status cannot be changed via update',
+    );
+  });
+
+  it('should reject startsOn field', () => {
+    expect(() => validateUpdateSeries({ startsOn: '2026-09-01' })).toThrow(
+      'startsOn cannot be changed after creation',
+    );
+  });
+
+  it('should reject empty title', () => {
+    expect(() => validateUpdateSeries({ title: '' })).toThrow(
+      'title must be a non-empty string',
+    );
+  });
+
+  it('should reject invalid assignedTo', () => {
+    expect(() => validateUpdateSeries({ assignedTo: 'Nobody' })).toThrow(
+      'assignedTo must be one of',
+    );
+  });
+
+  it('should reject invalid kind', () => {
+    expect(() => validateUpdateSeries({ kind: 'reminder' })).toThrow(
+      'kind must be one of',
+    );
+  });
+
+  it('should validate recurrenceRule if provided', () => {
+    validateUpdateSeries({ recurrenceRule: 'FREQ=DAILY' });
+    expect(validateRRule).toHaveBeenCalledWith('FREQ=DAILY');
+  });
+
+  it('should reject empty recurrenceRule', () => {
+    expect(() => validateUpdateSeries({ recurrenceRule: '' })).toThrow(
+      'recurrenceRule must be a non-empty string',
+    );
+  });
+
+  it('should accept nullable fields', () => {
+    const result = validateUpdateSeries({
+      description: null,
+      location: null,
+      startTime: null,
+      endTime: null,
+      endsOn: null,
+    });
+    expect(result.description).toBeNull();
+    expect(result.location).toBeNull();
+    expect(result.startTime).toBeNull();
+    expect(result.endTime).toBeNull();
+    expect(result.endsOn).toBeNull();
+  });
+
+  it('should accept an empty update body', () => {
+    const result = validateUpdateSeries({});
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});
+
+// --- listSeriesService ---
+
+describe('listSeriesService', () => {
+  it('should return all active series', async () => {
+    const series = [createTestTaskSeries()];
+    (getAllActiveTaskSeries as jest.Mock).mockResolvedValue(series);
+
+    const result = await listSeriesService();
+    expect(result).toEqual(series);
+  });
+});
+
+// --- getSeriesByIdService ---
+
+describe('getSeriesByIdService', () => {
+  it('should return a series by id', async () => {
+    const series = createTestTaskSeries();
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    const result = await getSeriesByIdService('series-1');
+    expect(result).toEqual(series);
+  });
+
+  it('should return undefined if not found', async () => {
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await getSeriesByIdService('missing');
+    expect(result).toBeUndefined();
+  });
+});
+
+// --- createSeriesService ---
+
+describe('createSeriesService', () => {
+  it('should create a series and trigger materialization', async () => {
+    const category = createTestTaskCategory();
+    const series = createTestTaskSeries();
+    const tasks = [createTestRecurringTask()];
+
+    (getTaskCategoryById as jest.Mock).mockResolvedValue(category);
+    (insertTaskSeries as jest.Mock).mockResolvedValue(series);
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (expandRRule as jest.Mock).mockReturnValue(['2026-08-04']);
+    (getCanceledExceptionDates as jest.Mock).mockResolvedValue([]);
+    (materializeOccurrences as jest.Mock).mockResolvedValue(tasks);
+
+    const result = await createSeriesService(createTestCreateSeriesRequest());
+
+    expect(result.series).toEqual(series);
+    expect(result.tasks).toEqual(tasks);
+    expect(insertTaskSeries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'active',
+        recurrence_rule: 'FREQ=WEEKLY;BYDAY=MO',
+      }),
+    );
+  });
+
+  it('should reject non-existent category', async () => {
+    (getTaskCategoryById as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(
+      createSeriesService(createTestCreateSeriesRequest()),
+    ).rejects.toThrow('Category not found');
+  });
+
+  it('should map camelCase to snake_case for insert', async () => {
+    const category = createTestTaskCategory();
+    const series = createTestTaskSeries();
+
+    (getTaskCategoryById as jest.Mock).mockResolvedValue(category);
+    (insertTaskSeries as jest.Mock).mockResolvedValue(series);
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (expandRRule as jest.Mock).mockReturnValue([]);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    await createSeriesService(createTestCreateSeriesRequest());
+
+    expect(insertTaskSeries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assigned_to: 'Yogi',
+        category_id: 'cat-1',
+        time_mode: 'timed',
+        start_time: '09:00',
+        starts_on: '2026-08-01',
+      }),
+    );
+  });
+});
+
+// --- updateSeriesService ---
+
+describe('updateSeriesService', () => {
+  it('should update series fields', async () => {
+    const series = createTestTaskSeries();
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue({
+      ...series,
+      title: 'Updated',
+    });
+
+    const result = await updateSeriesService('series-1', {
+      title: 'Updated',
+    });
+    expect(result.title).toBe('Updated');
+  });
+
+  it('should throw if series not found', async () => {
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(
+      updateSeriesService('missing', { title: 'Nope' }),
+    ).rejects.toThrow('Series not found');
+  });
+
+  it('should verify new category exists when changing categoryId', async () => {
+    const series = createTestTaskSeries();
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (getTaskCategoryById as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(
+      updateSeriesService('series-1', { categoryId: 'cat-999' }),
+    ).rejects.toThrow('Category not found');
+  });
+
+  it('should reject removing startTime when timeMode is timed', async () => {
+    const series = createTestTaskSeries({ timeMode: 'timed' });
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    await expect(
+      updateSeriesService('series-1', { startTime: null }),
+    ).rejects.toThrow('startTime is required when timeMode is timed');
+  });
+
+  it('should map camelCase to snake_case for update', async () => {
+    const series = createTestTaskSeries();
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    await updateSeriesService('series-1', {
+      recurrenceRule: 'FREQ=DAILY',
+      endTime: null,
+    });
+
+    expect(updateTaskSeriesById).toHaveBeenCalledWith('series-1', {
+      recurrence_rule: 'FREQ=DAILY',
+      end_time: null,
+    });
+  });
+});
+
+// --- pauseSeriesService ---
+
+describe('pauseSeriesService', () => {
+  it('should pause an active series', async () => {
+    const series = createTestTaskSeries({ status: 'active' });
+    const paused = { ...series, status: 'paused' };
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(paused);
+
+    const result = await pauseSeriesService('series-1');
+    expect(result.status).toBe('paused');
+    expect(updateTaskSeriesById).toHaveBeenCalledWith('series-1', {
+      status: 'paused',
+    });
+  });
+
+  it('should throw if series not found', async () => {
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(pauseSeriesService('missing')).rejects.toThrow(
+      'Series not found',
+    );
+  });
+
+  it('should reject invalid transition', async () => {
+    const series = createTestTaskSeries({ status: 'archived' });
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    await expect(pauseSeriesService('series-1')).rejects.toThrow(
+      'Cannot transition from archived to paused',
+    );
+  });
+});
+
+// --- resumeSeriesService ---
+
+describe('resumeSeriesService', () => {
+  it('should resume a paused series and trigger materialization', async () => {
+    const series = createTestTaskSeries({ status: 'paused' });
+    const active = { ...series, status: 'active' };
+    const tasks = [createTestRecurringTask()];
+
+    (getTaskSeriesById as jest.Mock)
+      .mockResolvedValueOnce(series)
+      .mockResolvedValueOnce(active);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(active);
+    (expandRRule as jest.Mock).mockReturnValue(['2026-08-04']);
+    (getCanceledExceptionDates as jest.Mock).mockResolvedValue([]);
+    (materializeOccurrences as jest.Mock).mockResolvedValue(tasks);
+
+    const result = await resumeSeriesService('series-1');
+    expect(result.series.status).toBe('active');
+    expect(result.tasks).toEqual(tasks);
+  });
+
+  it('should throw if series not found', async () => {
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(resumeSeriesService('missing')).rejects.toThrow(
+      'Series not found',
+    );
+  });
+
+  it('should reject invalid transition', async () => {
+    const series = createTestTaskSeries({ status: 'active' });
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    await expect(resumeSeriesService('series-1')).rejects.toThrow(
+      'Cannot transition from active to active',
+    );
+  });
+});
+
+// --- archiveSeriesService ---
+
+describe('archiveSeriesService', () => {
+  it('should archive an active series', async () => {
+    const series = createTestTaskSeries({ status: 'active' });
+    const archived = { ...series, status: 'archived' };
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(archived);
+
+    const result = await archiveSeriesService('series-1');
+    expect(result.status).toBe('archived');
+  });
+
+  it('should archive a paused series', async () => {
+    const series = createTestTaskSeries({ status: 'paused' });
+    const archived = { ...series, status: 'archived' };
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(archived);
+
+    const result = await archiveSeriesService('series-1');
+    expect(result.status).toBe('archived');
+  });
+
+  it('should reject archiving an already archived series', async () => {
+    const series = createTestTaskSeries({ status: 'archived' });
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    await expect(archiveSeriesService('series-1')).rejects.toThrow(
+      'Cannot transition from archived to archived',
+    );
+  });
+});
+
+// --- ensureTaskOccurrences ---
+
+describe('ensureTaskOccurrences', () => {
+  it('should generate tasks for a date range', async () => {
+    const series = createTestTaskSeries({
+      generatedThrough: null,
+    });
+    const tasks = [createTestRecurringTask()];
+
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (expandRRule as jest.Mock).mockReturnValue(['2026-08-04', '2026-08-11']);
+    (getCanceledExceptionDates as jest.Mock).mockResolvedValue([]);
+    (materializeOccurrences as jest.Mock).mockResolvedValue(tasks);
+
+    const result = await ensureTaskOccurrences('series-1', '2026-10-29');
+
+    expect(expandRRule).toHaveBeenCalledWith(
+      'FREQ=WEEKLY;BYDAY=MO',
+      '2026-08-01',
+      '2026-07-31',
+      '2026-10-29',
+      null,
+    );
+    expect(materializeOccurrences).toHaveBeenCalledWith(
+      'series-1',
+      expect.arrayContaining([
+        expect.objectContaining({
+          series_id: 'series-1',
+          original_occurrence_date: '2026-08-04',
+          title: 'Weekly Standup',
+          status: 'planned',
+          is_exception: false,
+        }),
+      ]),
+      '2026-10-29',
+    );
+    expect(result).toEqual(tasks);
+  });
+
+  it('should return empty array for paused series', async () => {
+    const series = createTestTaskSeries({ status: 'paused' });
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    const result = await ensureTaskOccurrences('series-1', '2026-10-29');
+    expect(result).toEqual([]);
+    expect(expandRRule).not.toHaveBeenCalled();
+  });
+
+  it('should return empty array for non-existent series', async () => {
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await ensureTaskOccurrences('missing', '2026-10-29');
+    expect(result).toEqual([]);
+  });
+
+  it('should skip canceled exception dates', async () => {
+    const series = createTestTaskSeries({ generatedThrough: null });
+
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (expandRRule as jest.Mock).mockReturnValue([
+      '2026-08-04',
+      '2026-08-11',
+      '2026-08-18',
+    ]);
+    (getCanceledExceptionDates as jest.Mock).mockResolvedValue(['2026-08-11']);
+    (materializeOccurrences as jest.Mock).mockResolvedValue([]);
+
+    await ensureTaskOccurrences('series-1', '2026-10-29');
+
+    const taskRows = (materializeOccurrences as jest.Mock).mock.calls[0][1];
+    const dates = taskRows.map(
+      (r: Record<string, unknown>) => r.original_occurrence_date,
+    );
+    expect(dates).toContain('2026-08-04');
+    expect(dates).not.toContain('2026-08-11');
+    expect(dates).toContain('2026-08-18');
+  });
+
+  it('should use generatedThrough as after date for incremental fill', async () => {
+    const series = createTestTaskSeries({
+      generatedThrough: '2026-09-15',
+    });
+
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (expandRRule as jest.Mock).mockReturnValue(['2026-09-22']);
+    (getCanceledExceptionDates as jest.Mock).mockResolvedValue([]);
+    (materializeOccurrences as jest.Mock).mockResolvedValue([]);
+
+    await ensureTaskOccurrences('series-1', '2026-10-29');
+
+    expect(expandRRule).toHaveBeenCalledWith(
+      'FREQ=WEEKLY;BYDAY=MO',
+      '2026-08-01',
+      '2026-09-15',
+      '2026-10-29',
+      null,
+    );
+  });
+
+  it('should respect endsOn as effective end boundary', async () => {
+    const series = createTestTaskSeries({
+      generatedThrough: null,
+      endsOn: '2026-09-01',
+    });
+
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (expandRRule as jest.Mock).mockReturnValue([]);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    await ensureTaskOccurrences('series-1', '2026-10-29');
+
+    expect(expandRRule).toHaveBeenCalledWith(
+      'FREQ=WEEKLY;BYDAY=MO',
+      '2026-08-01',
+      '2026-07-31',
+      '2026-09-01',
+      '2026-09-01',
+    );
+  });
+
+  it('should return empty when nothing to generate', async () => {
+    const series = createTestTaskSeries({
+      generatedThrough: '2026-10-30',
+    });
+
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    const result = await ensureTaskOccurrences('series-1', '2026-10-29');
+    expect(result).toEqual([]);
+    expect(expandRRule).not.toHaveBeenCalled();
+  });
+
+  it('should update generated_through when expansion returns no dates', async () => {
+    const series = createTestTaskSeries({ generatedThrough: null });
+
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (expandRRule as jest.Mock).mockReturnValue([]);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(series);
+
+    await ensureTaskOccurrences('series-1', '2026-10-29');
+
+    expect(updateTaskSeriesById).toHaveBeenCalledWith('series-1', {
+      generated_through: '2026-10-29',
+    });
+  });
+
+  it('should snapshot series defaults into task rows', async () => {
+    const series = createTestTaskSeries({
+      generatedThrough: null,
+      title: 'Team Sync',
+      description: 'Weekly team meeting',
+      kind: 'event',
+      modality: 'virtual',
+      timeMode: 'timed',
+      startTime: '09:00:00',
+      endTime: '09:30:00',
+      location: 'https://zoom.us/123',
+      metadata: { room: 'A' },
+    });
+
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(series);
+    (expandRRule as jest.Mock).mockReturnValue(['2026-08-04']);
+    (getCanceledExceptionDates as jest.Mock).mockResolvedValue([]);
+    (materializeOccurrences as jest.Mock).mockResolvedValue([]);
+
+    await ensureTaskOccurrences('series-1', '2026-10-29');
+
+    const taskRows = (materializeOccurrences as jest.Mock).mock.calls[0][1];
+    expect(taskRows[0]).toEqual(
+      expect.objectContaining({
+        title: 'Team Sync',
+        description: 'Weekly team meeting',
+        kind: 'event',
+        modality: 'virtual',
+        time_mode: 'timed',
+        start_time: '09:00:00',
+        end_time: '09:30:00',
+        location: 'https://zoom.us/123',
+        metadata: { room: 'A' },
+        status: 'planned',
+        is_exception: false,
+        assigned_to: 'Yogi',
+        category_id: 'cat-1',
+        series_id: 'series-1',
+        task_date: '2026-08-04',
+        original_occurrence_date: '2026-08-04',
+      }),
+    );
+  });
+});
+
+// --- ensureOccurrencesForDateRange ---
+
+describe('ensureOccurrencesForDateRange', () => {
+  it('should materialize each qualifying series', async () => {
+    const s1 = createTestTaskSeries({ id: 'series-1' });
+    const s2 = createTestTaskSeries({ id: 'series-2' });
+
+    (getSeriesNeedingMaterialization as jest.Mock).mockResolvedValue([s1, s2]);
+    (getTaskSeriesById as jest.Mock).mockResolvedValue(
+      createTestTaskSeries({ status: 'active' }),
+    );
+    (expandRRule as jest.Mock).mockReturnValue([]);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(
+      createTestTaskSeries(),
+    );
+
+    await ensureOccurrencesForDateRange('2026-08-01', '2026-10-29');
+
+    expect(getSeriesNeedingMaterialization).toHaveBeenCalledWith('2026-10-29');
+  });
+
+  it('should continue on individual series error', async () => {
+    const s1 = createTestTaskSeries({ id: 'series-1' });
+    const s2 = createTestTaskSeries({ id: 'series-2' });
+
+    (getSeriesNeedingMaterialization as jest.Mock).mockResolvedValue([s1, s2]);
+    (getTaskSeriesById as jest.Mock)
+      .mockRejectedValueOnce(new Error('DB error'))
+      .mockResolvedValueOnce(
+        createTestTaskSeries({ id: 'series-2', status: 'active' }),
+      );
+    (expandRRule as jest.Mock).mockReturnValue([]);
+    (updateTaskSeriesById as jest.Mock).mockResolvedValue(
+      createTestTaskSeries(),
+    );
+
+    await expect(
+      ensureOccurrencesForDateRange('2026-08-01', '2026-10-29'),
+    ).resolves.not.toThrow();
+  });
+
+  it('should do nothing when no series need materialization', async () => {
+    (getSeriesNeedingMaterialization as jest.Mock).mockResolvedValue([]);
+
+    await ensureOccurrencesForDateRange('2026-08-01', '2026-10-29');
+
+    expect(getTaskSeriesById).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/task-controller.test.ts
+++ b/src/__tests__/task-controller.test.ts
@@ -14,6 +14,7 @@ import {
   validateCreateCategory,
   validateUpdateCategory,
 } from '../server/services/taskService';
+import { listSeriesService } from '../server/services/seriesService';
 import {
   createTestTask,
   createTestTaskCategory,
@@ -34,6 +35,19 @@ jest.mock('../server/services/taskService', () => ({
   createTaskService: jest.fn(),
   updateTaskService: jest.fn(),
   deleteTaskService: jest.fn(),
+}));
+
+jest.mock('../server/services/seriesService', () => ({
+  validateCreateSeries: jest.fn(),
+  validateUpdateSeries: jest.fn(),
+  listSeriesService: jest.fn(),
+  getSeriesByIdService: jest.fn(),
+  createSeriesService: jest.fn(),
+  updateSeriesService: jest.fn(),
+  pauseSeriesService: jest.fn(),
+  resumeSeriesService: jest.fn(),
+  archiveSeriesService: jest.fn(),
+  ensureOccurrencesForDateRange: jest.fn().mockResolvedValue(undefined),
 }));
 
 afterAll(async () => {
@@ -310,12 +324,14 @@ describe('DELETE /tasks/:id', () => {
   });
 });
 
-// --- Series placeholder ---
+// --- Series listing ---
 
 describe('GET /tasks/series', () => {
-  it('should return 501 Not Implemented', async () => {
+  it('should return a list of active series', async () => {
+    (listSeriesService as jest.Mock).mockResolvedValue([]);
+
     const response = await request(app).get('/tasks/series');
-    expect(response.status).toBe(501);
-    expect(response.body.error).toBe('Not implemented');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
   });
 });

--- a/src/__tests__/task-service.test.ts
+++ b/src/__tests__/task-service.test.ts
@@ -39,6 +39,11 @@ jest.mock('../server/utils/db-operation-helpers', () => ({
   insertTask: jest.fn(),
   updateTaskById: jest.fn(),
   softDeleteTask: jest.fn(),
+  getSeriesNeedingMaterialization: jest.fn(),
+}));
+
+jest.mock('../server/services/seriesService', () => ({
+  ensureOccurrencesForDateRange: jest.fn().mockResolvedValue(undefined),
 }));
 
 afterEach(() => {
@@ -442,15 +447,35 @@ describe('updateTaskService', () => {
 // --- deleteTaskService ---
 
 describe('deleteTaskService', () => {
-  it('should soft-delete the task', async () => {
+  it('should soft-delete a one-time task', async () => {
+    const task = createTestTask({ seriesId: null });
+    (getTaskById as jest.Mock).mockResolvedValue(task);
     (softDeleteTask as jest.Mock).mockResolvedValue(true);
 
     await deleteTaskService('task-1');
     expect(softDeleteTask).toHaveBeenCalledWith('task-1');
   });
 
+  it('should cancel a recurring occurrence instead of soft-deleting', async () => {
+    const task = createTestTask({ seriesId: 'series-1' });
+    (getTaskById as jest.Mock).mockResolvedValue(task);
+    (updateTaskById as jest.Mock).mockResolvedValue({
+      ...task,
+      status: 'canceled',
+      isException: true,
+    });
+
+    await deleteTaskService('task-1');
+    expect(softDeleteTask).not.toHaveBeenCalled();
+    expect(updateTaskById).toHaveBeenCalledWith('task-1', {
+      status: 'canceled',
+      is_exception: true,
+      canceled_at: expect.any(String),
+    });
+  });
+
   it('should throw if task not found', async () => {
-    (softDeleteTask as jest.Mock).mockResolvedValue(false);
+    (getTaskById as jest.Mock).mockResolvedValue(undefined);
 
     await expect(deleteTaskService('missing')).rejects.toThrow(
       'Task not found',

--- a/src/server/controllers/seriesController.ts
+++ b/src/server/controllers/seriesController.ts
@@ -1,0 +1,121 @@
+import { Request, Response } from 'express';
+import logger from '../utils/logger';
+import {
+  validateCreateSeries,
+  validateUpdateSeries,
+  listSeriesService,
+  getSeriesByIdService,
+  createSeriesService,
+  updateSeriesService,
+  pauseSeriesService,
+  resumeSeriesService,
+  archiveSeriesService,
+} from '../services/seriesService';
+
+export const listSeriesController = async (_req: Request, res: Response) => {
+  try {
+    const series = await listSeriesService();
+    res.json(series);
+  } catch (error) {
+    logger.error(`Error fetching series: ${error}`);
+    res.status(500).json({ error: `Internal Server Error ${error}` });
+  }
+};
+
+export const getSeriesController = async (req: Request, res: Response) => {
+  try {
+    const series = await getSeriesByIdService(req.params.id);
+    if (!series) {
+      res.status(404).json({ error: 'Series not found' });
+      return;
+    }
+    res.json(series);
+  } catch (error) {
+    logger.error(`Error fetching series: ${error}`);
+    res.status(500).json({ error: `Internal Server Error ${error}` });
+  }
+};
+
+export const createSeriesController = async (req: Request, res: Response) => {
+  try {
+    const validated = validateCreateSeries(req.body);
+    const result = await createSeriesService(validated);
+    res.status(201).json(result);
+  } catch (error) {
+    logger.error(`Error creating series: ${error}`);
+    res.status(400).json({ error: `Failed to create series: ${error}` });
+  }
+};
+
+export const updateSeriesController = async (req: Request, res: Response) => {
+  try {
+    const validated = validateUpdateSeries(req.body);
+    const series = await updateSeriesService(req.params.id, validated);
+    res.json(series);
+  } catch (error) {
+    logger.error(`Error updating series: ${error}`);
+    const msg = (error as Error).message || '';
+    if (msg.includes('not found')) {
+      res.status(404).json({ error: msg });
+      return;
+    }
+    res.status(400).json({ error: `Failed to update series: ${error}` });
+  }
+};
+
+export const pauseSeriesController = async (req: Request, res: Response) => {
+  try {
+    const series = await pauseSeriesService(req.params.id);
+    res.json(series);
+  } catch (error) {
+    logger.error(`Error pausing series: ${error}`);
+    const msg = (error as Error).message || '';
+    if (msg.includes('not found')) {
+      res.status(404).json({ error: msg });
+      return;
+    }
+    if (msg.includes('Cannot transition')) {
+      res.status(400).json({ error: msg });
+      return;
+    }
+    res.status(500).json({ error: `Internal Server Error ${error}` });
+  }
+};
+
+export const resumeSeriesController = async (req: Request, res: Response) => {
+  try {
+    const result = await resumeSeriesService(req.params.id);
+    res.json(result);
+  } catch (error) {
+    logger.error(`Error resuming series: ${error}`);
+    const msg = (error as Error).message || '';
+    if (msg.includes('not found')) {
+      res.status(404).json({ error: msg });
+      return;
+    }
+    if (msg.includes('Cannot transition')) {
+      res.status(400).json({ error: msg });
+      return;
+    }
+    res.status(500).json({ error: `Internal Server Error ${error}` });
+  }
+};
+
+export const archiveSeriesController = async (req: Request, res: Response) => {
+  try {
+    const series = await archiveSeriesService(req.params.id);
+    res.json(series);
+  } catch (error) {
+    logger.error(`Error archiving series: ${error}`);
+    const msg = (error as Error).message || '';
+    if (msg.includes('not found')) {
+      res.status(404).json({ error: msg });
+      return;
+    }
+    if (msg.includes('Cannot transition')) {
+      res.status(400).json({ error: msg });
+      return;
+    }
+    res.status(500).json({ error: `Internal Server Error ${error}` });
+  }
+};

--- a/src/server/routes/taskRoutes.ts
+++ b/src/server/routes/taskRoutes.ts
@@ -9,6 +9,15 @@ import {
   updateTaskController,
   deleteTaskController,
 } from '../controllers/taskController';
+import {
+  listSeriesController,
+  getSeriesController,
+  createSeriesController,
+  updateSeriesController,
+  pauseSeriesController,
+  resumeSeriesController,
+  archiveSeriesController,
+} from '../controllers/seriesController';
 
 const router = Router();
 
@@ -17,10 +26,14 @@ router.get('/categories', listCategoriesController);
 router.post('/categories', createCategoryController);
 router.patch('/categories/:id', updateCategoryController);
 
-// Series placeholder (PR 2)
-router.get('/series', (_req, res) => {
-  res.status(501).json({ error: 'Not implemented' });
-});
+// Series routes
+router.get('/series', listSeriesController);
+router.post('/series', createSeriesController);
+router.get('/series/:id', getSeriesController);
+router.patch('/series/:id', updateSeriesController);
+router.post('/series/:id/pause', pauseSeriesController);
+router.post('/series/:id/resume', resumeSeriesController);
+router.post('/series/:id/archive', archiveSeriesController);
 
 // Task listing
 router.get('/', listTasksController);

--- a/src/server/services/seriesService.ts
+++ b/src/server/services/seriesService.ts
@@ -1,0 +1,469 @@
+import dayjs from 'dayjs';
+import logger from '../utils/logger';
+import {
+  VALID_TASK_KINDS,
+  VALID_TASK_MODALITIES,
+  VALID_TASK_TIME_MODES,
+  VALID_ASSIGNED_TO,
+  VALID_SERIES_STATUS_TRANSITIONS,
+  DEFAULT_MATERIALIZATION_HORIZON_DAYS,
+} from '../utils/consts';
+import {
+  getTaskCategoryById,
+  getTaskSeriesById,
+  getAllActiveTaskSeries,
+  getSeriesNeedingMaterialization,
+  insertTaskSeries,
+  updateTaskSeriesById,
+  getCanceledExceptionDates,
+  materializeOccurrences,
+} from '../utils/db-operation-helpers';
+import { validateRRule, expandRRule } from '../utils/rruleHelper';
+import {
+  Task,
+  TaskSeries,
+  CreateSeriesRequest,
+  UpdateSeriesRequest,
+} from '../utils/types';
+
+// --- Validation ---
+
+export const validateCreateSeries = (body: unknown): CreateSeriesRequest => {
+  const data = body as Record<string, unknown>;
+
+  if (!data.title || typeof data.title !== 'string') {
+    throw new Error('title is required');
+  }
+  if (
+    !data.assignedTo ||
+    !(VALID_ASSIGNED_TO as readonly string[]).includes(
+      data.assignedTo as string,
+    )
+  ) {
+    throw new Error(
+      `assignedTo must be one of: ${VALID_ASSIGNED_TO.join(', ')}`,
+    );
+  }
+  if (!data.categoryId || typeof data.categoryId !== 'string') {
+    throw new Error('categoryId is required');
+  }
+  if (
+    !data.kind ||
+    !(VALID_TASK_KINDS as readonly string[]).includes(data.kind as string)
+  ) {
+    throw new Error(`kind must be one of: ${VALID_TASK_KINDS.join(', ')}`);
+  }
+  if (
+    !data.modality ||
+    !(VALID_TASK_MODALITIES as readonly string[]).includes(
+      data.modality as string,
+    )
+  ) {
+    throw new Error(
+      `modality must be one of: ${VALID_TASK_MODALITIES.join(', ')}`,
+    );
+  }
+  if (
+    !data.timeMode ||
+    !(VALID_TASK_TIME_MODES as readonly string[]).includes(
+      data.timeMode as string,
+    )
+  ) {
+    throw new Error(
+      `timeMode must be one of: ${VALID_TASK_TIME_MODES.join(', ')}`,
+    );
+  }
+  if (data.timeMode === 'timed' && !data.startTime) {
+    throw new Error('startTime is required when timeMode is timed');
+  }
+  if (!data.startsOn || typeof data.startsOn !== 'string') {
+    throw new Error('startsOn is required');
+  }
+  if (!data.recurrenceRule || typeof data.recurrenceRule !== 'string') {
+    throw new Error('recurrenceRule is required');
+  }
+  validateRRule(data.recurrenceRule);
+
+  if (data.endsOn !== undefined && data.endsOn !== null) {
+    if (typeof data.endsOn !== 'string' || !data.endsOn) {
+      throw new Error('endsOn must be a non-empty string');
+    }
+    if (data.endsOn < (data.startsOn as string)) {
+      throw new Error('endsOn must be on or after startsOn');
+    }
+  }
+  if (
+    data.metadata !== undefined &&
+    (typeof data.metadata !== 'object' ||
+      data.metadata === null ||
+      Array.isArray(data.metadata))
+  ) {
+    throw new Error('metadata must be a plain object');
+  }
+
+  return {
+    assignedTo: data.assignedTo as string,
+    title: data.title as string,
+    description: data.description as string | undefined,
+    categoryId: data.categoryId as string,
+    kind: data.kind as string,
+    modality: data.modality as string,
+    location: data.location as string | undefined,
+    timeMode: data.timeMode as string,
+    startTime: data.startTime as string | undefined,
+    endTime: data.endTime as string | undefined,
+    startsOn: data.startsOn as string,
+    endsOn: data.endsOn as string | undefined,
+    recurrenceRule: data.recurrenceRule as string,
+    metadata: data.metadata as Record<string, unknown> | undefined,
+  };
+};
+
+export const validateUpdateSeries = (body: unknown): UpdateSeriesRequest => {
+  const data = body as Record<string, unknown>;
+  const result: UpdateSeriesRequest = {};
+
+  if ('status' in data) {
+    throw new Error(
+      'status cannot be changed via update; use action endpoints',
+    );
+  }
+  if ('startsOn' in data) {
+    throw new Error('startsOn cannot be changed after creation');
+  }
+
+  if (data.title !== undefined) {
+    if (typeof data.title !== 'string' || !data.title) {
+      throw new Error('title must be a non-empty string');
+    }
+    result.title = data.title;
+  }
+  if (data.assignedTo !== undefined) {
+    if (
+      !(VALID_ASSIGNED_TO as readonly string[]).includes(
+        data.assignedTo as string,
+      )
+    ) {
+      throw new Error(
+        `assignedTo must be one of: ${VALID_ASSIGNED_TO.join(', ')}`,
+      );
+    }
+    result.assignedTo = data.assignedTo as string;
+  }
+  if (data.categoryId !== undefined) {
+    if (typeof data.categoryId !== 'string' || !data.categoryId) {
+      throw new Error('categoryId must be a non-empty string');
+    }
+    result.categoryId = data.categoryId;
+  }
+  if (data.kind !== undefined) {
+    if (
+      !(VALID_TASK_KINDS as readonly string[]).includes(data.kind as string)
+    ) {
+      throw new Error(`kind must be one of: ${VALID_TASK_KINDS.join(', ')}`);
+    }
+    result.kind = data.kind as string;
+  }
+  if (data.modality !== undefined) {
+    if (
+      !(VALID_TASK_MODALITIES as readonly string[]).includes(
+        data.modality as string,
+      )
+    ) {
+      throw new Error(
+        `modality must be one of: ${VALID_TASK_MODALITIES.join(', ')}`,
+      );
+    }
+    result.modality = data.modality as string;
+  }
+  if (data.timeMode !== undefined) {
+    if (
+      !(VALID_TASK_TIME_MODES as readonly string[]).includes(
+        data.timeMode as string,
+      )
+    ) {
+      throw new Error(
+        `timeMode must be one of: ${VALID_TASK_TIME_MODES.join(', ')}`,
+      );
+    }
+    result.timeMode = data.timeMode as string;
+  }
+  if (data.recurrenceRule !== undefined) {
+    if (typeof data.recurrenceRule !== 'string' || !data.recurrenceRule) {
+      throw new Error('recurrenceRule must be a non-empty string');
+    }
+    validateRRule(data.recurrenceRule);
+    result.recurrenceRule = data.recurrenceRule;
+  }
+  if ('endsOn' in data) {
+    result.endsOn = (data.endsOn as string | null) ?? null;
+  }
+  if ('description' in data) {
+    result.description = (data.description as string | null) ?? null;
+  }
+  if ('location' in data) {
+    result.location = (data.location as string | null) ?? null;
+  }
+  if ('startTime' in data) {
+    result.startTime = (data.startTime as string | null) ?? null;
+  }
+  if ('endTime' in data) {
+    result.endTime = (data.endTime as string | null) ?? null;
+  }
+  if (data.metadata !== undefined) {
+    if (
+      typeof data.metadata !== 'object' ||
+      data.metadata === null ||
+      Array.isArray(data.metadata)
+    ) {
+      throw new Error('metadata must be a plain object');
+    }
+    result.metadata = data.metadata as Record<string, unknown>;
+  }
+
+  return result;
+};
+
+// --- Series CRUD ---
+
+export const listSeriesService = async (): Promise<TaskSeries[]> => {
+  return await getAllActiveTaskSeries();
+};
+
+export const getSeriesByIdService = async (
+  id: string,
+): Promise<TaskSeries | undefined> => {
+  return await getTaskSeriesById(id);
+};
+
+export const createSeriesService = async (
+  data: CreateSeriesRequest,
+): Promise<{ series: TaskSeries; tasks: Task[] }> => {
+  const category = await getTaskCategoryById(data.categoryId);
+  if (!category) {
+    throw new Error(`Category not found: ${data.categoryId}`);
+  }
+
+  const series = await insertTaskSeries({
+    assigned_to: data.assignedTo,
+    title: data.title,
+    description: data.description ?? null,
+    category_id: data.categoryId,
+    kind: data.kind,
+    modality: data.modality,
+    location: data.location ?? null,
+    time_mode: data.timeMode,
+    start_time: data.startTime ?? null,
+    end_time: data.endTime ?? null,
+    starts_on: data.startsOn,
+    ends_on: data.endsOn ?? null,
+    recurrence_rule: data.recurrenceRule,
+    status: 'active',
+    metadata: data.metadata ?? {},
+  });
+
+  const horizonDate = dayjs()
+    .add(DEFAULT_MATERIALIZATION_HORIZON_DAYS, 'day')
+    .format('YYYY-MM-DD');
+  const tasks = await ensureTaskOccurrences(series.id, horizonDate);
+
+  return { series, tasks };
+};
+
+export const updateSeriesService = async (
+  id: string,
+  data: UpdateSeriesRequest,
+): Promise<TaskSeries> => {
+  const existing = await getTaskSeriesById(id);
+  if (!existing) {
+    throw new Error('Series not found');
+  }
+
+  if (data.categoryId && data.categoryId !== existing.categoryId) {
+    const category = await getTaskCategoryById(data.categoryId);
+    if (!category) {
+      throw new Error(`Category not found: ${data.categoryId}`);
+    }
+  }
+
+  const effectiveTimeMode = data.timeMode ?? existing.timeMode;
+  const effectiveStartTime =
+    'startTime' in data ? data.startTime : existing.startTime;
+  if (effectiveTimeMode === 'timed' && !effectiveStartTime) {
+    throw new Error('startTime is required when timeMode is timed');
+  }
+
+  const dbData: Record<string, unknown> = {};
+  if (data.title !== undefined) dbData.title = data.title;
+  if ('description' in data) dbData.description = data.description ?? null;
+  if (data.assignedTo !== undefined) dbData.assigned_to = data.assignedTo;
+  if (data.categoryId !== undefined) dbData.category_id = data.categoryId;
+  if (data.kind !== undefined) dbData.kind = data.kind;
+  if (data.modality !== undefined) dbData.modality = data.modality;
+  if (data.timeMode !== undefined) dbData.time_mode = data.timeMode;
+  if ('startTime' in data) dbData.start_time = data.startTime ?? null;
+  if ('endTime' in data) dbData.end_time = data.endTime ?? null;
+  if ('location' in data) dbData.location = data.location ?? null;
+  if ('endsOn' in data) dbData.ends_on = data.endsOn ?? null;
+  if (data.recurrenceRule !== undefined)
+    dbData.recurrence_rule = data.recurrenceRule;
+  if (data.metadata !== undefined) dbData.metadata = data.metadata;
+
+  const updated = await updateTaskSeriesById(id, dbData);
+  if (!updated) {
+    throw new Error('Series not found');
+  }
+  return updated;
+};
+
+// --- Series Actions ---
+
+export const pauseSeriesService = async (id: string): Promise<TaskSeries> => {
+  const existing = await getTaskSeriesById(id);
+  if (!existing) {
+    throw new Error('Series not found');
+  }
+
+  const allowed = VALID_SERIES_STATUS_TRANSITIONS[existing.status];
+  if (!allowed || !allowed.includes('paused')) {
+    throw new Error(`Cannot transition from ${existing.status} to paused`);
+  }
+
+  const updated = await updateTaskSeriesById(id, { status: 'paused' });
+  if (!updated) {
+    throw new Error('Series not found');
+  }
+  return updated;
+};
+
+export const resumeSeriesService = async (
+  id: string,
+): Promise<{ series: TaskSeries; tasks: Task[] }> => {
+  const existing = await getTaskSeriesById(id);
+  if (!existing) {
+    throw new Error('Series not found');
+  }
+
+  const allowed = VALID_SERIES_STATUS_TRANSITIONS[existing.status];
+  if (!allowed || !allowed.includes('active')) {
+    throw new Error(`Cannot transition from ${existing.status} to active`);
+  }
+
+  const updated = await updateTaskSeriesById(id, { status: 'active' });
+  if (!updated) {
+    throw new Error('Series not found');
+  }
+
+  const horizonDate = dayjs()
+    .add(DEFAULT_MATERIALIZATION_HORIZON_DAYS, 'day')
+    .format('YYYY-MM-DD');
+  const tasks = await ensureTaskOccurrences(updated.id, horizonDate);
+
+  return { series: updated, tasks };
+};
+
+export const archiveSeriesService = async (id: string): Promise<TaskSeries> => {
+  const existing = await getTaskSeriesById(id);
+  if (!existing) {
+    throw new Error('Series not found');
+  }
+
+  const allowed = VALID_SERIES_STATUS_TRANSITIONS[existing.status];
+  if (!allowed || !allowed.includes('archived')) {
+    throw new Error(`Cannot transition from ${existing.status} to archived`);
+  }
+
+  const updated = await updateTaskSeriesById(id, { status: 'archived' });
+  if (!updated) {
+    throw new Error('Series not found');
+  }
+  return updated;
+};
+
+// --- Materialization ---
+
+export const ensureTaskOccurrences = async (
+  seriesId: string,
+  throughDate: string,
+): Promise<Task[]> => {
+  const series = await getTaskSeriesById(seriesId);
+  if (!series || series.status !== 'active') {
+    return [];
+  }
+
+  // effectiveStart is exclusive — subtract 1 day from startsOn so startsOn itself is included
+  const effectiveStart = series.generatedThrough
+    ? series.generatedThrough
+    : dayjs(series.startsOn).subtract(1, 'day').format('YYYY-MM-DD');
+
+  const effectiveEnd =
+    series.endsOn && series.endsOn < throughDate ? series.endsOn : throughDate;
+
+  if (effectiveStart >= effectiveEnd) {
+    return [];
+  }
+
+  const dates = expandRRule(
+    series.recurrenceRule,
+    series.startsOn,
+    effectiveStart,
+    effectiveEnd,
+    series.endsOn,
+  );
+
+  if (dates.length === 0) {
+    await updateTaskSeriesById(seriesId, {
+      generated_through: effectiveEnd,
+    });
+    return [];
+  }
+
+  const canceledDates = await getCanceledExceptionDates(seriesId);
+  const canceledSet = new Set(canceledDates);
+  const filteredDates = dates.filter((d) => !canceledSet.has(d));
+
+  if (filteredDates.length === 0) {
+    await updateTaskSeriesById(seriesId, {
+      generated_through: effectiveEnd,
+    });
+    return [];
+  }
+
+  const taskRows = filteredDates.map((date) => ({
+    assigned_to: series.assignedTo,
+    series_id: series.id,
+    original_occurrence_date: date,
+    title: series.title,
+    description: series.description,
+    category_id: series.categoryId,
+    kind: series.kind,
+    modality: series.modality,
+    status: 'planned',
+    task_date: date,
+    time_mode: series.timeMode,
+    start_time: series.startTime,
+    end_time: series.endTime,
+    location: series.location,
+    is_exception: false,
+    metadata: series.metadata,
+  }));
+
+  return await materializeOccurrences(seriesId, taskRows, effectiveEnd);
+};
+
+export const ensureOccurrencesForDateRange = async (
+  _from: string,
+  to: string,
+): Promise<void> => {
+  const seriesList = await getSeriesNeedingMaterialization(to);
+
+  for (const series of seriesList) {
+    try {
+      await ensureTaskOccurrences(series.id, to);
+    } catch (error) {
+      logger.error(
+        `Failed to materialize occurrences for series ${series.id}: ${error}`,
+      );
+    }
+  }
+};

--- a/src/server/services/taskService.ts
+++ b/src/server/services/taskService.ts
@@ -17,6 +17,7 @@ import {
   updateTaskById,
   softDeleteTask,
 } from '../utils/db-operation-helpers';
+import { ensureOccurrencesForDateRange } from './seriesService';
 import {
   Task,
   TaskCategory,
@@ -301,6 +302,7 @@ export const listTasksService = async (
   status?: string,
   assignedTo?: string,
 ): Promise<Task[]> => {
+  await ensureOccurrencesForDateRange(from, to);
   return await getTasksByDateRange(from, to, status, assignedTo);
 };
 
@@ -395,8 +397,24 @@ export const updateTaskService = async (
 };
 
 export const deleteTaskService = async (id: string): Promise<void> => {
-  const deleted = await softDeleteTask(id);
-  if (!deleted) {
+  const existing = await getTaskById(id);
+  if (!existing) {
     throw new Error('Task not found');
+  }
+
+  if (existing.seriesId) {
+    const updated = await updateTaskById(id, {
+      status: 'canceled',
+      is_exception: true,
+      canceled_at: new Date().toISOString(),
+    });
+    if (!updated) {
+      throw new Error('Task not found');
+    }
+  } else {
+    const deleted = await softDeleteTask(id);
+    if (!deleted) {
+      throw new Error('Task not found');
+    }
   }
 };

--- a/src/server/utils/consts.ts
+++ b/src/server/utils/consts.ts
@@ -52,3 +52,27 @@ export const VALID_STATUS_TRANSITIONS: Record<string, string[]> = {
   skipped: ['planned'],
   canceled: [],
 };
+
+// Series error messages
+export const ErrorFetchingTaskSeries = 'Error fetching task series';
+export const ErrorInsertingTaskSeries = 'Error inserting task series';
+export const ErrorUpdatingTaskSeries = 'Error updating task series';
+export const ErrorMaterializingOccurrences =
+  'Error materializing task occurrences';
+
+// Series status transitions
+export const VALID_SERIES_STATUS_TRANSITIONS: Record<string, string[]> = {
+  active: ['paused', 'ended', 'archived'],
+  paused: ['active', 'archived'],
+  ended: ['archived'],
+  archived: [],
+};
+
+// Materialization
+export const DEFAULT_MATERIALIZATION_HORIZON_DAYS = 90;
+export const SUPPORTED_RRULE_FREQUENCIES = [
+  'DAILY',
+  'WEEKLY',
+  'MONTHLY',
+  'YEARLY',
+] as const;

--- a/src/server/utils/data-factory/taskTestDataFactory.ts
+++ b/src/server/utils/data-factory/taskTestDataFactory.ts
@@ -1,8 +1,10 @@
 import {
   Task,
   TaskCategory,
+  TaskSeries,
   CreateTaskRequest,
   CreateCategoryRequest,
+  CreateSeriesRequest,
 } from '../types';
 
 export const createTestTaskCategory = (
@@ -67,5 +69,74 @@ export const createTestCreateCategoryRequest = (
   name: 'Custom',
   slug: 'custom',
   colorKey: 'primary',
+  ...overrides,
+});
+
+export const createTestTaskSeries = (
+  overrides: Partial<TaskSeries> = {},
+): TaskSeries => ({
+  id: 'series-1',
+  assignedTo: 'Yogi',
+  title: 'Weekly Standup',
+  description: null,
+  categoryId: 'cat-1',
+  kind: 'event',
+  modality: 'virtual',
+  location: null,
+  timeMode: 'timed',
+  startTime: '09:00:00',
+  endTime: '09:30:00',
+  startsOn: '2026-08-01',
+  endsOn: null,
+  recurrenceRule: 'FREQ=WEEKLY;BYDAY=MO',
+  status: 'active',
+  generatedThrough: null,
+  metadata: {},
+  createdAt: '2026-07-27T00:00:00.000Z',
+  updatedAt: '2026-07-27T00:00:00.000Z',
+  deletedAt: null,
+  ...overrides,
+});
+
+export const createTestCreateSeriesRequest = (
+  overrides: Partial<CreateSeriesRequest> = {},
+): CreateSeriesRequest => ({
+  assignedTo: 'Yogi',
+  title: 'Weekly Standup',
+  categoryId: 'cat-1',
+  kind: 'event',
+  modality: 'virtual',
+  timeMode: 'timed',
+  startTime: '09:00',
+  startsOn: '2026-08-01',
+  recurrenceRule: 'FREQ=WEEKLY;BYDAY=MO',
+  ...overrides,
+});
+
+export const createTestRecurringTask = (
+  overrides: Partial<Task> = {},
+): Task => ({
+  id: 'task-r1',
+  assignedTo: 'Yogi',
+  seriesId: 'series-1',
+  originalOccurrenceDate: '2026-08-04',
+  title: 'Weekly Standup',
+  description: null,
+  categoryId: 'cat-1',
+  kind: 'event',
+  modality: 'virtual',
+  status: 'planned',
+  taskDate: '2026-08-04',
+  timeMode: 'timed',
+  startTime: '09:00:00',
+  endTime: '09:30:00',
+  location: null,
+  isException: false,
+  metadata: {},
+  completedAt: null,
+  canceledAt: null,
+  createdAt: '2026-07-27T00:00:00.000Z',
+  updatedAt: '2026-07-27T00:00:00.000Z',
+  deletedAt: null,
   ...overrides,
 });

--- a/src/server/utils/db-operation-helpers.ts
+++ b/src/server/utils/db-operation-helpers.ts
@@ -11,6 +11,7 @@ import {
   MonthlyExpenseWithReimbursable,
   Task,
   TaskCategory,
+  TaskSeries,
   UpdateExpenseType,
   WordnikWordOfTheDayResponse,
 } from './types';
@@ -26,6 +27,10 @@ import {
   ErrorUpdatingTask,
   ErrorUpdatingTaskCategory,
   ErrorDeletingTask,
+  ErrorFetchingTaskSeries,
+  ErrorInsertingTaskSeries,
+  ErrorUpdatingTaskSeries,
+  ErrorMaterializingOccurrences,
 } from './consts';
 import { validateReimbursableExpense } from './utils';
 
@@ -628,6 +633,201 @@ export const softDeleteTask = async (id: string): Promise<boolean> => {
     return count > 0;
   } catch (error) {
     logger.error(`${ErrorDeletingTask}: ${error}`);
+    throw error;
+  }
+};
+
+// --- Task Series DB Operations ---
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const formatTaskSeriesRow = (row: any): TaskSeries => ({
+  id: row.id,
+  assignedTo: row.assigned_to,
+  title: row.title,
+  description: row.description,
+  categoryId: row.category_id,
+  kind: row.kind,
+  modality: row.modality,
+  location: row.location,
+  timeMode: row.time_mode,
+  startTime: row.start_time,
+  endTime: row.end_time,
+  startsOn: dayjs(row.starts_on).format('YYYY-MM-DD'),
+  endsOn: row.ends_on ? dayjs(row.ends_on).format('YYYY-MM-DD') : null,
+  recurrenceRule: row.recurrence_rule,
+  status: row.status,
+  generatedThrough: row.generated_through
+    ? dayjs(row.generated_through).format('YYYY-MM-DD')
+    : null,
+  metadata: row.metadata,
+  createdAt: dayjs(row.created_at).toISOString(),
+  updatedAt: dayjs(row.updated_at).toISOString(),
+  deletedAt: row.deleted_at ? dayjs(row.deleted_at).toISOString() : null,
+});
+
+export const getTaskSeriesById = async (
+  id: string,
+): Promise<TaskSeries | undefined> => {
+  try {
+    const row = await db('task_series')
+      .select('*')
+      .where('id', id)
+      .whereNull('deleted_at')
+      .first();
+
+    return row ? formatTaskSeriesRow(row) : undefined;
+  } catch (error) {
+    logger.error(`${ErrorFetchingTaskSeries}: ${error}`);
+    throw error;
+  }
+};
+
+export const getAllActiveTaskSeries = async (): Promise<TaskSeries[]> => {
+  try {
+    const rows = await db('task_series')
+      .select('*')
+      .where('status', 'active')
+      .whereNull('deleted_at')
+      .orderBy('created_at', 'desc');
+
+    return rows.map(formatTaskSeriesRow);
+  } catch (error) {
+    logger.error(`${ErrorFetchingTaskSeries}: ${error}`);
+    throw error;
+  }
+};
+
+export const getSeriesNeedingMaterialization = async (
+  throughDate: string,
+): Promise<TaskSeries[]> => {
+  try {
+    const rows = await db('task_series')
+      .select('*')
+      .where('status', 'active')
+      .where('starts_on', '<=', throughDate)
+      .where(function () {
+        this.whereNull('ends_on').orWhere('ends_on', '>=', throughDate);
+      })
+      .where(function () {
+        this.whereNull('generated_through').orWhere(
+          'generated_through',
+          '<',
+          throughDate,
+        );
+      })
+      .whereNull('deleted_at');
+
+    return rows.map(formatTaskSeriesRow);
+  } catch (error) {
+    logger.error(`${ErrorFetchingTaskSeries}: ${error}`);
+    throw error;
+  }
+};
+
+export const insertTaskSeries = async (
+  data: Record<string, unknown>,
+): Promise<TaskSeries> => {
+  try {
+    const [row] = await db('task_series').insert(data).returning('*');
+
+    logger.info(`Inserted task series ${row.id}`);
+    return formatTaskSeriesRow(row);
+  } catch (error) {
+    logger.error(`${ErrorInsertingTaskSeries}: ${error}`);
+    throw error;
+  }
+};
+
+export const updateTaskSeriesById = async (
+  id: string,
+  data: Record<string, unknown>,
+): Promise<TaskSeries | undefined> => {
+  try {
+    const rows = await db('task_series')
+      .where('id', id)
+      .whereNull('deleted_at')
+      .update({ ...data, updated_at: db.fn.now() })
+      .returning('*');
+
+    if (!rows.length) return undefined;
+
+    logger.info(`Updated task series ${id}`);
+    return formatTaskSeriesRow(rows[0]);
+  } catch (error) {
+    logger.error(`${ErrorUpdatingTaskSeries}: ${error}`);
+    throw error;
+  }
+};
+
+export const getCanceledExceptionDates = async (
+  seriesId: string,
+): Promise<string[]> => {
+  try {
+    const rows = await db('tasks')
+      .select('original_occurrence_date')
+      .where('series_id', seriesId)
+      .where('is_exception', true)
+      .where('status', 'canceled');
+
+    return rows.map((r: { original_occurrence_date: string }) =>
+      dayjs(r.original_occurrence_date).format('YYYY-MM-DD'),
+    );
+  } catch (error) {
+    logger.error(`${ErrorFetchingTask}: ${error}`);
+    throw error;
+  }
+};
+
+export const materializeOccurrences = async (
+  seriesId: string,
+  taskRows: Record<string, unknown>[],
+  throughDate: string,
+): Promise<Task[]> => {
+  try {
+    return await db.transaction(async (trx) => {
+      let insertedTasks: Task[] = [];
+
+      if (taskRows.length > 0) {
+        const columns = Object.keys(taskRows[0]);
+        const valuePlaceholders = taskRows
+          .map(() => `(${columns.map(() => '?').join(', ')})`)
+          .join(', ');
+        const flatValues: (string | number | boolean | null)[] =
+          taskRows.flatMap((row) =>
+            columns.map((col) => {
+              const val = row[col];
+              if (typeof val === 'object' && val !== null)
+                return JSON.stringify(val);
+              return val as string | number | boolean | null;
+            }),
+          );
+
+        const columnList = columns.join(', ');
+        const result = await trx.raw(
+          `INSERT INTO tasks (${columnList}) VALUES ${valuePlaceholders}
+           ON CONFLICT (series_id, original_occurrence_date)
+           WHERE series_id IS NOT NULL
+           DO NOTHING
+           RETURNING *`,
+          flatValues,
+        );
+
+        insertedTasks = result.rows.map(formatTaskRow);
+      }
+
+      await trx('task_series').where('id', seriesId).update({
+        generated_through: throughDate,
+        updated_at: trx.fn.now(),
+      });
+
+      logger.info(
+        `Materialized ${insertedTasks.length} occurrences for series ${seriesId} through ${throughDate}`,
+      );
+
+      return insertedTasks;
+    });
+  } catch (error) {
+    logger.error(`${ErrorMaterializingOccurrences}: ${error}`);
     throw error;
   }
 };

--- a/src/server/utils/rruleHelper.ts
+++ b/src/server/utils/rruleHelper.ts
@@ -1,0 +1,62 @@
+import { RRule, Frequency } from 'rrule';
+import { SUPPORTED_RRULE_FREQUENCIES } from './consts';
+
+const FREQ_NAME_MAP: Record<number, string> = {
+  [Frequency.YEARLY]: 'YEARLY',
+  [Frequency.MONTHLY]: 'MONTHLY',
+  [Frequency.WEEKLY]: 'WEEKLY',
+  [Frequency.DAILY]: 'DAILY',
+  [Frequency.HOURLY]: 'HOURLY',
+  [Frequency.MINUTELY]: 'MINUTELY',
+  [Frequency.SECONDLY]: 'SECONDLY',
+};
+
+export const validateRRule = (ruleString: string): void => {
+  let rule: RRule;
+  try {
+    rule = RRule.fromString(ruleString);
+  } catch {
+    throw new Error(`Invalid recurrence rule: ${ruleString}`);
+  }
+
+  const freqName = FREQ_NAME_MAP[rule.options.freq];
+  if (
+    !freqName ||
+    !(SUPPORTED_RRULE_FREQUENCIES as readonly string[]).includes(freqName)
+  ) {
+    throw new Error(
+      `Unsupported frequency: ${freqName || rule.options.freq}. Supported: ${SUPPORTED_RRULE_FREQUENCIES.join(', ')}`,
+    );
+  }
+};
+
+export const expandRRule = (
+  ruleString: string,
+  startsOn: string,
+  after: string,
+  before: string,
+  endsOn?: string | null,
+): string[] => {
+  const effectiveBefore = endsOn && endsOn < before ? endsOn : before;
+
+  const parsed = RRule.parseString(ruleString);
+  const rule = new RRule({
+    ...parsed,
+    dtstart: new Date(startsOn + 'T00:00:00Z'),
+  });
+
+  const afterDate = new Date(after + 'T00:00:00Z');
+  const beforeDate = new Date(effectiveBefore + 'T00:00:00Z');
+
+  // between with inc=true includes both boundaries; filter out afterDate for exclusive lower bound
+  const dates = rule.between(afterDate, beforeDate, true);
+
+  return dates
+    .filter((d) => d.getTime() > afterDate.getTime())
+    .map((d) => {
+      const y = d.getUTCFullYear();
+      const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+      const day = String(d.getUTCDate()).padStart(2, '0');
+      return `${y}-${m}-${day}`;
+    });
+};

--- a/src/server/utils/types.ts
+++ b/src/server/utils/types.ts
@@ -267,3 +267,61 @@ export type UpdateCategoryRequest = {
   sortOrder?: number;
   isActive?: boolean;
 };
+
+// Series types
+
+export type TaskSeries = {
+  id: string;
+  assignedTo: string;
+  title: string;
+  description: string | null;
+  categoryId: string;
+  kind: string;
+  modality: string;
+  location: string | null;
+  timeMode: string;
+  startTime: string | null;
+  endTime: string | null;
+  startsOn: string;
+  endsOn: string | null;
+  recurrenceRule: string;
+  status: string;
+  generatedThrough: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+};
+
+export type CreateSeriesRequest = {
+  assignedTo: string;
+  title: string;
+  description?: string;
+  categoryId: string;
+  kind: string;
+  modality: string;
+  location?: string;
+  timeMode: string;
+  startTime?: string;
+  endTime?: string;
+  startsOn: string;
+  endsOn?: string;
+  recurrenceRule: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type UpdateSeriesRequest = {
+  title?: string;
+  description?: string | null;
+  assignedTo?: string;
+  categoryId?: string;
+  kind?: string;
+  modality?: string;
+  location?: string | null;
+  timeMode?: string;
+  startTime?: string | null;
+  endTime?: string | null;
+  endsOn?: string | null;
+  recurrenceRule?: string;
+  metadata?: Record<string, unknown>;
+};


### PR DESCRIPTION
### What
Implements recurring task series: CRUD, pause/resume/archive lifecycle actions, and RRULE-based occurrence materialization, building on the one-time task CRUD from PR 1.

### Why
Per the Task Planning V1 design doc (docs/features/todo.md), Ticket 3 adds recurrence on top of the one-time task foundation (Ticket 2) without making the calendar/dashboard aware of series definitions — recurring items are still just rows in tasks, generated from a task_series definition and kept idempotent via the (series_id, original_occurrence_date) unique constraint from PR 1's migration.

### Changes
RRULE handling (src/server/utils/rruleHelper.ts): wraps the rrule package (added to package.json) to validate recurrence strings and restrict them to DAILY/WEEKLY/MONTHLY/YEARLY (per SUPPORTED_RRULE_FREQUENCIES), and to expand a rule into concrete occurrence dates within a date window.

Series layer, following the existing routes → controllers → services → db-operation-helpers pattern:

seriesController.ts — list/get/create/update series, plus pause/resume/archive action endpoints

seriesService.ts — validation (mirrors task validation: required fields, enum checks, timed series require startTime, endsOn can't precede startsOn), CRUD, status-transition guards (VALID_SERIES_STATUS_TRANSITIONS), and the materialization flow

db-operation-helpers.ts — new series queries (getTaskSeriesById, getAllActiveTaskSeries, getSeriesNeedingMaterialization, insertTaskSeries, updateTaskSeriesById, getCanceledExceptionDates) and materializeOccurrences, which bulk-inserts generated rows in a transaction via ON CONFLICT (series_id, original_occurrence_date) DO NOTHING and advances generated_through
Materialization (ensureTaskOccurrences, ensureOccurrencesForDateRange in seriesService.ts): expands a series' RRULE out to a 90-day horizon (DEFAULT_MATERIALIZATION_HORIZON_DAYS), skips dates that were previously canceled as exceptions, and is called from listTasksService so occurrences are generated lazily whenever a date range is queried
Routes: taskRoutes.ts replaces the 501 series placeholder from PR 1 with real endpoints — GET/POST /tasks/series, GET/PATCH /tasks/series/:id, POST /tasks/series/:id/{pause,resume,archive}

Occurrence cancellation: deleteTaskService (taskService.ts) now branches on whether a task belongs to a series — recurring occurrences are canceled (status: canceled, is_exception: true) instead of hard-deleted, so materialization won't regenerate them; one-time tasks are still soft-deleted as before

Types/consts: adds TaskSeries, CreateSeriesRequest, UpdateSeriesRequest to types.ts; adds series error strings, VALID_SERIES_STATUS_TRANSITIONS, DEFAULT_MATERIALIZATION_HORIZON_DAYS, and SUPPORTED_RRULE_FREQUENCIES to consts.ts

Tests: adds rrule-helper.test.ts, series-controller.test.ts, series-service.test.ts, and extends taskTestDataFactory.ts with series/recurring-task factories; existing task-controller.test.ts/task-service.test.ts updated for the new cancel-vs-delete branch




Not included: the task/recurrence UI and dashboard/calendar projection — tracked as Tickets 4 & 5 in the design doc.